### PR TITLE
Issue #46: tag-derived version truth

### DIFF
--- a/.codex/prompts/issue_46.md
+++ b/.codex/prompts/issue_46.md
@@ -1,0 +1,19 @@
+Issue: https://github.com/dave0875/HealthDelta/issues/46
+
+Scope / intent (immutable)
+- Establish version truth derived from git tags so published artifacts are traceable to an exact version and git SHA:
+  - Python packaging version for wheel/sdist
+  - `healthdelta version` CLI for share-safe reporting
+  - iOS versioning strategy for CI/TestFlight builds (marketing version + build number)
+  - container metadata requirements (OCI labels + `/version` output) specified for follow-on work
+
+Acceptance criteria (restated)
+- On tag `vX.Y.Z`, `Release` workflow produces Python dist with version `X.Y.Z`.
+- `healthdelta version` prints a share-safe version string and (when available) a git SHA.
+- iOS distribution builds on tag `vX.Y.Z` can set marketing version to `X.Y.Z` and a deterministic build number (implemented as scripts/helpers usable by future workflows).
+- `CI` remains green; `Release` on tag is deployment proof for this change.
+
+Constraints
+- Deterministic, testable logic; follow TDD for non-trivial parsing/version logic.
+- No secrets committed.
+

--- a/.codex/sessions/2026-01-22/session_45.md
+++ b/.codex/sessions/2026-01-22/session_45.md
@@ -1,0 +1,21 @@
+# Session 45 — 2026-01-22
+
+Issues worked
+- #46 CD: Establish version truth across artifacts (Python + iOS + container metadata)
+
+Execution environment
+- Repository mutations executed on Ubuntu host: `GORF`
+
+Work summary
+- Switched Python packaging to tag-derived versioning via `setuptools_scm` (`pyproject.toml`).
+- Added share-safe build/version reporting:
+  - `healthdelta version` CLI command
+  - `healthdelta/version.py` helpers for version + git SHA
+- Hardened release artifact proof:
+  - `Release` workflow now fetches tags (`fetch-depth: 0`)
+  - tag builds verify wheel version matches `vX.Y.Z`
+- Added helper for future iOS distribution workflows: `scripts/cd/derive_ios_versions.py`
+
+Local verification
+- `python3 -m unittest discover -s tests -p 'test_*.py' -v` (pass; some DuckDB tests skipped locally due to missing `duckdb` module)
+- `python -m build` in a local venv (pass)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -27,6 +29,18 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install build
           python -m build
+
+      - name: Verify dist version matches tag (tag builds only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          expected="${GITHUB_REF#refs/tags/v}"
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          actual="$(python -c 'from importlib.metadata import version; print(version("healthdelta"))')"
+          echo "expected=$expected"
+          echo "actual=$actual"
+          test "$actual" = "$expected"
 
       - name: Upload CLI dist artifact
         uses: actions/upload-artifact@v4

--- a/docs/issues/ISSUE-0046.md
+++ b/docs/issues/ISSUE-0046.md
@@ -1,0 +1,35 @@
+# ISSUE-0046: CD: Establish version truth across artifacts (Python + iOS + container metadata)
+
+GitHub: https://github.com/dave0875/HealthDelta/issues/46
+
+## Objective
+Make versioning deterministic and tag-driven so every published artifact is traceable to an exact `vX.Y.Z` tag and git SHA.
+
+## Context / Why
+Continuous Deployment requires auditable version truth:
+- Python packaging is currently pinned to `0.0.0` (drift risk).
+- iOS marketing/build versions are currently hard-coded in the project definition.
+Without tag-driven versioning and accessible version reporting, deploy verification and rollback become error-prone.
+
+## Acceptance Criteria
+- Given a release tag `vX.Y.Z`, when the `Release` workflow runs, then the built wheel/sdist report version `X.Y.Z`.
+- Given any environment where HealthDelta runs, when executing `healthdelta version`, then it prints a share-safe version string and (when available) a git SHA.
+- Given a tag `vX.Y.Z`, when building iOS for distribution in CI (follow-on workflow), then marketing version is `X.Y.Z` and build number is deterministic and traceable to the CI run.
+- CI proof: `.github/workflows/ci.yml` stays green on the implementing PR.
+- Deployment proof: `.github/workflows/release.yml` on tag `vX.Y.Z` produces artifacts whose embedded version matches the tag.
+
+## Non-Goals
+- Backend containerization and ORIN deployment automation.
+- Fastlane/TestFlight upload automation (handled in follow-on issues).
+
+## Risks
+- Risk: shallow clones prevent tag-based version resolution.
+  - Mitigation: configure workflows to fetch tags where required for version computation.
+
+## Test Plan
+- Local: `python3 -m unittest discover -s tests -p 'test_*.py' -v`
+- Local (optional): `python -m build` to verify wheel/sdist generation
+
+## Rollback Plan
+- Revert versioning changes and restore fixed versioning if needed.
+

--- a/docs/runbook_cd.md
+++ b/docs/runbook_cd.md
@@ -22,14 +22,17 @@ This runbook defines how HealthDelta produces share-safe build artifacts and wha
 - Only share-safe derived artifacts may be published (code builds, logs, synthetic test fixtures, CI reports).
 
 ## How to cut a CLI release
-1) Decide the version and update it in `pyproject.toml` (must be tracked by an issue).
+1) Decide the version and ensure `main` is ready to tag (must be tracked by an issue).
 2) Create an annotated tag `vX.Y.Z` on `main`.
 3) Push the tag to GitHub.
 4) Confirm the `Release` workflow run is green and the GitHub Release has the expected assets attached.
 
+Note: CLI packaging version is tag-derived; do not manually edit a fixed `version = ...` field in `pyproject.toml`.
+
 ## iOS distribution (current state)
 - TestFlight / App Store distribution is not configured by default.
 - Current authoritative proof for iOS is the macOS self-hosted CI runner (`ios-xcresult` artifact).
+- Planned: distribution builds will set `MARKETING_VERSION` from the git tag and `CURRENT_PROJECT_VERSION` from the CI run number (helper: `scripts/cd/derive_ios_versions.py`).
 
 ## References
 - Production targets ADR: `docs/adr/ADR_5_continuous_deployment_targets.md`

--- a/healthdelta/__init__.py
+++ b/healthdelta/__init__.py
@@ -1,2 +1,3 @@
-__all__ = []
+from healthdelta._version import __version__
 
+__all__ = ["__version__"]

--- a/healthdelta/_version.py
+++ b/healthdelta/_version.py
@@ -1,0 +1,1 @@
+__version__ = "0.0.post1.dev94"

--- a/healthdelta/pipeline.py
+++ b/healthdelta/pipeline.py
@@ -44,12 +44,9 @@ def _now_utc() -> str:
 
 
 def _healthdelta_version() -> str:
-    try:
-        from importlib.metadata import version
+    from healthdelta.version import get_version
 
-        return version("healthdelta")
-    except Exception:
-        return "0.0.0+local"
+    return get_version()
 
 
 def _redacted_input_summary(input_path: Path) -> dict:

--- a/healthdelta/version.py
+++ b/healthdelta/version.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any
+
+
+def parse_version_tag(ref_or_tag: str) -> str | None:
+    s = ref_or_tag.strip()
+    if s.startswith("refs/tags/"):
+        s = s[len("refs/tags/") :]
+
+    if not s.startswith("v"):
+        return None
+
+    v = s[1:]
+    parts = v.split(".")
+    if len(parts) != 3:
+        return None
+    if any((not p.isdigit()) for p in parts):
+        return None
+    return v
+
+
+def _run_git(args: list[str]) -> str | None:
+    try:
+        out = subprocess.check_output(["git", *args], stderr=subprocess.DEVNULL, text=True)
+    except Exception:
+        return None
+    return out.strip() or None
+
+
+def get_git_sha() -> str | None:
+    for key in ("HEALTHDELTA_GIT_SHA", "GITHUB_SHA"):
+        v = os.getenv(key)
+        if v:
+            return v
+    return _run_git(["rev-parse", "HEAD"])
+
+
+def get_version() -> str:
+    env_v = os.getenv("HEALTHDELTA_VERSION")
+    if env_v:
+        return env_v
+
+    try:
+        from healthdelta._version import __version__ as v
+
+        if v and v != "0.0.0+local":
+            return v
+    except Exception:
+        pass
+
+    try:
+        from importlib.metadata import version as dist_version
+
+        return dist_version("healthdelta")
+    except Exception:
+        pass
+
+    tag_v = parse_version_tag(os.getenv("GITHUB_REF", "") or "")
+    if tag_v:
+        return tag_v
+
+    return "0.0.0+local"
+
+
+def ios_marketing_version_from_ref(ref: str) -> str | None:
+    return parse_version_tag(ref)
+
+
+def ios_build_number_from_env() -> str | None:
+    run_number = os.getenv("GITHUB_RUN_NUMBER")
+    if run_number and run_number.isdigit():
+        return run_number
+    return None
+
+
+def get_build_info() -> dict[str, Any]:
+    return {
+        "version": get_version(),
+        "git_sha": get_git_sha(),
+        "github_ref": os.getenv("GITHUB_REF") or None,
+        "github_run_id": os.getenv("GITHUB_RUN_ID") or None,
+        "github_run_number": os.getenv("GITHUB_RUN_NUMBER") or None,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=68", "setuptools_scm[toml]>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "healthdelta"
-version = "0.0.0"
+dynamic = ["version"]
 description = "HealthDelta tooling"
 requires-python = ">=3.10"
 dependencies = [
@@ -17,3 +17,10 @@ healthdelta = "healthdelta.cli:main"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["healthdelta*"]
+
+[tool.setuptools_scm]
+tag_regex = "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$"
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
+write_to = "healthdelta/_version.py"
+write_to_template = "__version__ = \"{version}\"\n"

--- a/scripts/cd/derive_ios_versions.py
+++ b/scripts/cd/derive_ios_versions.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from healthdelta.version import ios_build_number_from_env, ios_marketing_version_from_ref
+
+
+def main() -> int:
+    ref = os.getenv("GITHUB_REF") or ""
+    marketing = ios_marketing_version_from_ref(ref)
+    build = ios_build_number_from_env()
+
+    if "--json" in sys.argv:
+        print(json.dumps({"MARKETING_VERSION": marketing, "CURRENT_PROJECT_VERSION": build}, sort_keys=True))
+        return 0
+
+    if marketing is not None:
+        print(f"MARKETING_VERSION={marketing}")
+    if build is not None:
+        print(f"CURRENT_PROJECT_VERSION={build}")
+
+    if marketing is None:
+        print("ERROR: expected GITHUB_REF to be a tag like refs/tags/vX.Y.Z", file=sys.stderr)
+        return 2
+    if build is None:
+        print("ERROR: expected GITHUB_RUN_NUMBER to be set (digits only)", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,38 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+
+
+class TestVersionTruth(unittest.TestCase):
+    def test_parse_tag_version_accepts_v_prefix(self) -> None:
+        from healthdelta.version import parse_version_tag
+
+        self.assertEqual(parse_version_tag("v1.2.3"), "1.2.3")
+
+    def test_parse_tag_version_accepts_refs_tags(self) -> None:
+        from healthdelta.version import parse_version_tag
+
+        self.assertEqual(parse_version_tag("refs/tags/v2.3.4"), "2.3.4")
+
+    def test_parse_tag_version_rejects_invalid(self) -> None:
+        from healthdelta.version import parse_version_tag
+
+        self.assertIsNone(parse_version_tag("1.2.3"))
+        self.assertIsNone(parse_version_tag("v1.2"))
+        self.assertIsNone(parse_version_tag("refs/heads/main"))
+
+    def test_healthdelta_version_command_prints_version_line(self) -> None:
+        from healthdelta.cli import main
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["version"])
+
+        self.assertEqual(rc, 0)
+        out = buf.getvalue().strip()
+        self.assertTrue(out.startswith("healthdelta_version="), out)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
- Closes #46

## Summary
- Switch Python packaging to tag-derived versions via `setuptools_scm`.
- Add `healthdelta version` and helper module to report version + git SHA.
- Harden `Release` workflow to fetch tags and verify built dist version matches the tag.
- Add helper script for future iOS distribution builds to derive marketing/build versions.

## Test plan
- `python3 -m unittest discover -s tests -p "test_*\.py" -v`