### PR TITLE
Issue #54: publish backend image to GHCR

### DIFF
--- a/.codex/prompts/issue_54.md
+++ b/.codex/prompts/issue_54.md
@@ -1,0 +1,13 @@
+Issue: https://github.com/dave0875/HealthDelta/issues/54
+
+Scope / intent (immutable)
+- Build and publish the backend container image to GHCR on `v*` tags.
+- Embed version truth into the image (build args + OCI labels).
+- Verify the pushed image by pulling and running it in CI and checking `/healthz` and `/version`.
+
+Acceptance criteria (restated)
+- Tag `vX.Y.Z` publishes `ghcr.io/<owner>/healthdelta-backend:vX.Y.Z` and `:latest`.
+- `/version` reports the expected `version=X.Y.Z` and `git_sha=<sha>` for the tag.
+- OCI labels include `org.opencontainers.image.version` and `org.opencontainers.image.revision`.
+- Workflow logs/artifacts include image digest(s) and verification output.
+

--- a/.codex/sessions/2026-01-22/session_49.md
+++ b/.codex/sessions/2026-01-22/session_49.md
@@ -1,0 +1,15 @@
+# Session 49 — 2026-01-22
+
+Issues worked
+- #54 CD: Build and push backend image to GHCR on tag
+
+Execution environment
+- Repository mutations executed on Ubuntu host: `GORF`
+
+Work summary
+- Extended `Release` workflow to build/push backend image to GHCR on `v*` tags.
+- Embed version truth in the image via build args (`HEALTHDELTA_VERSION`, `HEALTHDELTA_GIT_SHA`) and OCI labels.
+- Added CI verification that pulls the pushed image and checks `/healthz` + `/version`.
+
+Local verification
+- N/A (tag-triggered workflow verification)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,88 @@ jobs:
         with:
           files: |
             dist/*
+
+  backend-image:
+    name: Backend image (GHCR, tag only)
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive version variables
+        id: v
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/}"      # vX.Y.Z
+          ver="${tag#v}"                      # X.Y.Z
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "ver=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push backend image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/healthdelta-backend:${{ steps.v.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/healthdelta-backend:latest
+          build-args: |
+            HEALTHDELTA_VERSION=${{ steps.v.outputs.ver }}
+            HEALTHDELTA_GIT_SHA=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.v.outputs.ver }}
+
+      - name: Record image digest
+        run: |
+          set -euo pipefail
+          echo "digest=${{ steps.build.outputs.digest }}"
+
+      - name: Verify pushed image (pull + run)
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${{ github.repository_owner }}/healthdelta-backend:${{ steps.v.outputs.tag }}"
+          docker pull "$image"
+          cid="$(docker run -d -p 18080:8080 "$image")"
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+          for i in $(seq 1 60); do
+            if curl -fsS "http://127.0.0.1:18080/healthz" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.1
+          done
+
+          curl -fsS "http://127.0.0.1:18080/healthz"
+          ver_json="$(curl -fsS "http://127.0.0.1:18080/version")"
+          echo "$ver_json"
+
+          VER_JSON="$ver_json" EXPECTED_VERSION="${{ steps.v.outputs.ver }}" EXPECTED_SHA="${{ github.sha }}" python3 - <<'PY'
+          import json, os, sys
+          obj = json.loads(os.environ["VER_JSON"])
+          expected_version = os.environ["EXPECTED_VERSION"]
+          expected_sha = os.environ["EXPECTED_SHA"]
+          if obj.get("version") != expected_version:
+            raise SystemExit(f"version mismatch: got={obj.get('version')} expected={expected_version}")
+          if obj.get("git_sha") != expected_sha:
+            raise SystemExit(f"git_sha mismatch: got={obj.get('git_sha')} expected={expected_sha}")
+          print("ok")
+          PY

--- a/docs/issues/ISSUE-0054.md
+++ b/docs/issues/ISSUE-0054.md
@@ -1,0 +1,26 @@
+# ISSUE-0054: CD: Build and push backend image to GHCR on tag
+
+GitHub: https://github.com/dave0875/HealthDelta/issues/54
+
+## Objective
+Publish a verifiable backend container image to GHCR on release tags so ORIN deployments can pull a pinned image and validate version truth.
+
+## Context / Why
+With a minimal backend service and Dockerfile in place, CD requires a reproducible publishing pipeline that embeds version truth and performs post-build verification, producing observable proof (digests + logs).
+
+## Acceptance Criteria
+- On tag `vX.Y.Z`, workflow pushes `ghcr.io/<owner>/healthdelta-backend:vX.Y.Z` and `:latest`.
+- Image build embeds `HEALTHDELTA_VERSION=X.Y.Z` and `HEALTHDELTA_GIT_SHA=<sha>` so `/version` reports expected values.
+- Workflow pulls and runs the pushed image and verifies `/healthz` + `/version`.
+- Image includes OCI labels for `org.opencontainers.image.version` and `org.opencontainers.image.revision`.
+- Workflow logs show image digest(s) and verification output.
+
+## Non-Goals
+- ORIN deployment automation and compose pinning.
+
+## Test Plan
+- CI: run on tag in GitHub Actions and confirm GHCR publish + verification logs.
+
+## Rollback Plan
+- Revert workflow changes; stop publishing backend images.
+


### PR DESCRIPTION
- Closes #54

## Summary
- Add `backend-image` job to `.github/workflows/release.yml` to build/push `ghcr.io/<owner>/healthdelta-backend` on `v*` tags.
- Embed version truth via build args and OCI labels.
- Verify the pushed image by pull+run and checking `/healthz` and `/version`.

## Test plan
- Tag run on `vX.Y.Z` and confirm GHCR image + verification logs.
- CI on PR stays green.