### PR TITLE
Issue #56: fix Release tag version

### DIFF
--- a/.codex/prompts/issue_56.md
+++ b/.codex/prompts/issue_56.md
@@ -1,0 +1,11 @@
+Issue: https://github.com/dave0875/HealthDelta/issues/56
+
+Scope / intent (immutable)
+- Fix tag-triggered Release builds so Python wheel/sdist versions match the tag exactly (`vX.Y.Z` → `X.Y.Z`).
+- Keep CI green and re-verify by running Release on a new tag after the fix.
+
+Acceptance criteria (restated)
+- On tag `vX.Y.Z`, built dist version is exactly `X.Y.Z`.
+- Release workflow’s tag version verification passes.
+- Release workflow runs successfully on a new tag after the fix.
+

--- a/.codex/sessions/2026-01-22/session_50.md
+++ b/.codex/sessions/2026-01-22/session_50.md
@@ -1,0 +1,13 @@
+# Session 50 — 2026-01-22
+
+Issues worked
+- #56 Release: fix tag builds to produce exact PEP 440 version (no .post/.dev)
+
+Execution environment
+- Repository mutations executed on Ubuntu host: `GORF`
+
+Work summary
+- Updated `Release` workflow to force tag builds to use the exact tag version via `SETUPTOOLS_SCM_PRETEND_VERSION`.
+
+Local verification
+- N/A (workflow-driven change)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
           set -euo pipefail
           python -m pip install --upgrade pip
           python -m pip install build
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            export SETUPTOOLS_SCM_PRETEND_VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           python -m build
 
       - name: Verify dist version matches tag (tag builds only)

--- a/docs/issues/ISSUE-0056.md
+++ b/docs/issues/ISSUE-0056.md
@@ -1,0 +1,23 @@
+# ISSUE-0056: Release: fix tag builds to produce exact PEP 440 version (no .post/.dev)
+
+GitHub: https://github.com/dave0875/HealthDelta/issues/56
+
+## Objective
+Ensure tag-triggered Release builds embed the exact tag version into Python artifacts so version truth checks are deterministic.
+
+## Context / Why
+Tag `v0.0.1` produced `healthdelta-0.0.1.post1.dev0`, which caused the Release workflow’s tag version verification step to fail and blocks end-to-end release proof.
+
+## Acceptance Criteria
+- On tag `vX.Y.Z`, `python -m build` produces wheel/sdist with version exactly `X.Y.Z`.
+- Release workflow’s tag version verification step passes.
+- Deployment proof: Release workflow succeeds on a new tag after the fix.
+- CI remains green.
+
+## Non-Goals
+- Changing backend publishing behavior beyond aligning version truth.
+
+## Test Plan
+- CI: `CI` workflow green on PR.
+- Release proof: push a new tag after merge and confirm Release workflow is green.
+


### PR DESCRIPTION
- Closes #56

## Summary
- Set `SETUPTOOLS_SCM_PRETEND_VERSION` on `v*` tag builds so `python -m build` emits wheel/sdist version exactly `X.Y.Z`.

## Test plan
- CI green on PR.
- After merge, push tag `v0.0.2` and confirm `Release` workflow is green and version check passes.