### PR TITLE
Issue #60: ORIN deploy workflow + verification

### DIFF
--- a/.codex/prompts/issue_60.md
+++ b/.codex/prompts/issue_60.md
@@ -1,0 +1,14 @@
+Issue: https://github.com/dave0875/HealthDelta/issues/60
+
+Scope / intent (immutable)
+- Add tag-triggered backend deployment automation for ORIN using docker compose:
+  - pin image tag in `/opt/healthdelta` deployment directory
+  - `docker compose up -d` deploy
+  - post-deploy “150% verification” using `/healthz`, `/version`, and basic log scan
+- Document ORIN runner prerequisites, GHCR pull auth, and rollback steps.
+
+Acceptance criteria (restated)
+- On tag `vX.Y.Z`, deploy workflow runs on ORIN self-hosted runner and deploys pinned `ghcr.io/<owner>/healthdelta-backend:vX.Y.Z`.
+- Verification proves image tag, `/version` values, `/healthz` success, and no obvious fatal logs.
+- Rollback guidance exists; no secrets committed.
+

--- a/.codex/sessions/2026-01-22/session_52.md
+++ b/.codex/sessions/2026-01-22/session_52.md
@@ -1,0 +1,18 @@
+# Session 52 — 2026-01-22
+
+Issues worked
+- #60 CD: ORIN deploy workflow (docker compose) + post-deploy verification
+
+Execution environment
+- Repository mutations executed on Ubuntu host: `GORF`
+
+Work summary
+- Added ORIN deploy compose template: `deploy/orin/compose.yaml` with pinned tag via `.env`.
+- Added ORIN deploy workflow: `.github/workflows/deploy_backend_orin.yml` (tag-triggered; runs on ORIN self-hosted runner).
+- Added deploy/verify scripts:
+  - `scripts/cd/orin_deploy_backend.sh`
+  - `scripts/cd/orin_verify_backend.sh`
+- Added ORIN deployment runbook: `docs/runbook_orin_deploy.md`
+
+Local verification
+- N/A (requires ORIN self-hosted runner)

--- a/.github/workflows/deploy_backend_orin.yml
+++ b/.github/workflows/deploy_backend_orin.yml
@@ -1,0 +1,56 @@
+name: Deploy Backend (ORIN)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to deploy (vX.Y.Z)
+        required: true
+        type: string
+
+concurrency:
+  group: orin-backend-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: ORIN deploy + verify
+    runs-on: [self-hosted, linux, orin]
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to GHCR (pull)
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Derive deploy variables
+        id: v
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.tag }}"
+          if [ -z "$tag" ]; then
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          ver="${tag#v}"
+          sha="$(git rev-list -n 1 "$tag")"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "ver=$ver" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy + verify (compose)
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.v.outputs.tag }}" VERSION="${{ steps.v.outputs.ver }}" GIT_SHA="${{ steps.v.outputs.sha }}" \
+            DEPLOY_DIR="/opt/healthdelta" SERVICE_NAME="backend" BASE_URL="http://127.0.0.1:8080" \
+            bash scripts/cd/orin_deploy_backend.sh
+

--- a/deploy/orin/compose.yaml
+++ b/deploy/orin/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  backend:
+    image: ghcr.io/dave0875/healthdelta-backend:${HEALTHDELTA_BACKEND_IMAGE_TAG:-latest}
+    pull_policy: always
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+

--- a/deploy/orin/env.example
+++ b/deploy/orin/env.example
@@ -1,0 +1,4 @@
+# Pinned backend image tag for ORIN deploys.
+# Example: v0.0.2
+HEALTHDELTA_BACKEND_IMAGE_TAG=v0.0.2
+

--- a/docs/issues/ISSUE-0060.md
+++ b/docs/issues/ISSUE-0060.md
@@ -1,0 +1,27 @@
+# ISSUE-0060: CD: ORIN deploy workflow (docker compose) + post-deploy verification
+
+GitHub: https://github.com/dave0875/HealthDelta/issues/60
+
+## Objective
+Deploy the backend to ORIN automatically on tags using docker compose, with strong post-deploy verification and clear rollback guidance.
+
+## Context / Why
+Backend images are published to GHCR on tags and include `/healthz` and `/version`. ORIN deploy automation completes backend CD by pulling a pinned image tag on a LAN-local runner and validating the running version matches the tag.
+
+## Acceptance Criteria
+- On tag `vX.Y.Z`, deploy workflow runs on ORIN self-hosted runner and deploys `ghcr.io/<owner>/healthdelta-backend:vX.Y.Z` via docker compose in `/opt/healthdelta`.
+- Post-deploy verification proves:
+  - expected image tag is running
+  - `/version` reports `version=X.Y.Z` and `git_sha=<sha>`
+  - `/healthz` returns HTTP 200
+  - bounded log scan shows no obvious fatal errors
+- Rollback guidance exists (pin previous tag and redeploy).
+- No secrets committed; CI remains green.
+
+## Test Plan
+- CI: workflow files lint by Action runner; PR CI green.
+- ORIN: execute tag deploy once runner + secrets are configured (deployment proof).
+
+## Rollback Plan
+- Re-deploy previous tag by updating pinned tag and running compose up.
+

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -1,0 +1,52 @@
+# Runbook: ORIN backend deployment (docker compose)
+
+This runbook covers the ORIN-side prerequisites and operational commands for backend deployments.
+
+## Deployment workflow
+- Workflow: `.github/workflows/deploy_backend_orin.yml`
+- Trigger: tag `vX.Y.Z` (or manual dispatch with `tag=vX.Y.Z`)
+- Runner: ORIN self-hosted GitHub Actions runner (LAN-local)
+- Deploy dir: `/opt/healthdelta`
+
+## ORIN prerequisites
+1) GitHub Actions self-hosted runner installed on ORIN
+   - Labels must include: `self-hosted`, `linux`, `orin` (matches workflow `runs-on`)
+2) Docker installed and runner user can run Docker
+   - Runner user must be able to execute `docker` and `docker compose` without interactive prompts.
+3) Tools required for verification
+   - `curl`
+   - `python3`
+4) Deploy directory permissions
+   - Preferred: allow the runner user to write `/opt/healthdelta`:
+     - `sudo mkdir -p /opt/healthdelta`
+     - `sudo chown <runner-user>:<runner-user> /opt/healthdelta`
+   - The deploy workflow copies `deploy/orin/compose.yaml` and writes `/opt/healthdelta/.env` to pin the tag.
+
+## What gets deployed
+- Compose template: `deploy/orin/compose.yaml`
+- Pinned tag file: `/opt/healthdelta/.env` with `HEALTHDELTA_BACKEND_IMAGE_TAG=vX.Y.Z`
+- Service listens on `http://127.0.0.1:8080` (port mapping `8080:8080`)
+
+## Verification (“150%” backend checks)
+The deploy workflow verifies:
+- Correct image tag is running (container image contains `:vX.Y.Z`)
+- `GET /healthz` returns 200
+- `GET /version` returns `version=X.Y.Z` and `git_sha=<sha>`
+- Recent logs do not contain obvious fatal indicators (bounded tail scan)
+
+## Rollback
+1) Choose a previous tag (example: `v0.0.1`)
+2) Update `/opt/healthdelta/.env`:
+   - `HEALTHDELTA_BACKEND_IMAGE_TAG=v0.0.1`
+3) Redeploy:
+   - `cd /opt/healthdelta`
+   - `docker compose --env-file .env pull backend`
+   - `docker compose --env-file .env up -d --remove-orphans`
+4) Verify:
+   - `curl -fsS http://127.0.0.1:8080/healthz`
+   - `curl -fsS http://127.0.0.1:8080/version`
+
+## Credentials / secrets
+- The workflow uses `GITHUB_TOKEN` for `docker login ghcr.io` with `packages: read` permission.
+- If GHCR pulls fail on ORIN, use a fine-grained PAT with `read:packages` via a new secret and update the workflow accordingly (do not commit tokens).
+

--- a/scripts/cd/orin_deploy_backend.sh
+++ b/scripts/cd/orin_deploy_backend.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+DEPLOY_DIR="${DEPLOY_DIR:-/opt/healthdelta}"
+SERVICE_NAME="${SERVICE_NAME:-backend}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+
+TAG="${TAG:?tag to deploy (e.g., v0.0.2)}"
+VERSION="${VERSION:?expected version (e.g., 0.0.2)}"
+GIT_SHA="${GIT_SHA:?expected git sha}"
+
+if [ ! -d "$DEPLOY_DIR" ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo mkdir -p "$DEPLOY_DIR"
+    sudo chown "$USER":"$USER" "$DEPLOY_DIR"
+  else
+    echo "ERROR: deploy dir '$DEPLOY_DIR' does not exist and sudo is unavailable" >&2
+    exit 2
+  fi
+fi
+
+cp "$REPO_ROOT/deploy/orin/compose.yaml" "$DEPLOY_DIR/compose.yaml"
+cat >"$DEPLOY_DIR/.env" <<EOF
+HEALTHDELTA_BACKEND_IMAGE_TAG=$TAG
+EOF
+
+cd "$DEPLOY_DIR"
+
+docker compose --env-file .env pull "$SERVICE_NAME"
+docker compose --env-file .env up -d --remove-orphans
+
+DEPLOY_DIR="$DEPLOY_DIR" SERVICE_NAME="$SERVICE_NAME" BASE_URL="$BASE_URL" \
+  EXPECTED_TAG="$TAG" EXPECTED_VERSION="$VERSION" EXPECTED_SHA="$GIT_SHA" \
+  "$REPO_ROOT/scripts/cd/orin_verify_backend.sh"
+

--- a/scripts/cd/orin_verify_backend.sh
+++ b/scripts/cd/orin_verify_backend.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOY_DIR="${DEPLOY_DIR:-/opt/healthdelta}"
+SERVICE_NAME="${SERVICE_NAME:-backend}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+
+EXPECTED_TAG="${EXPECTED_TAG:?expected image tag (e.g., v0.0.2)}"
+EXPECTED_VERSION="${EXPECTED_VERSION:?expected version (e.g., 0.0.2)}"
+EXPECTED_SHA="${EXPECTED_SHA:?expected git sha}"
+
+cd "$DEPLOY_DIR"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker not found on runner" >&2
+  exit 2
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "ERROR: docker compose not available on runner" >&2
+  exit 2
+fi
+
+cid="$(docker compose ps -q "$SERVICE_NAME" || true)"
+if [ -z "$cid" ]; then
+  echo "ERROR: compose service '$SERVICE_NAME' container not found" >&2
+  docker compose ps || true
+  exit 2
+fi
+
+image="$(docker inspect --format '{{.Config.Image}}' "$cid" || true)"
+echo "container_id=$cid"
+echo "container_image=$image"
+
+if [[ "$image" != *":${EXPECTED_TAG}"* ]]; then
+  echo "ERROR: expected image tag ':${EXPECTED_TAG}' not found in '$image'" >&2
+  exit 1
+fi
+
+for i in $(seq 1 60); do
+  if curl -fsS "$BASE_URL/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+
+curl -fsS "$BASE_URL/healthz"
+ver_json="$(curl -fsS "$BASE_URL/version")"
+echo "$ver_json"
+
+VER_JSON="$ver_json" EXPECTED_VERSION="$EXPECTED_VERSION" EXPECTED_SHA="$EXPECTED_SHA" python3 - <<'PY'
+import json, os
+obj = json.loads(os.environ["VER_JSON"])
+expected_version = os.environ["EXPECTED_VERSION"]
+expected_sha = os.environ["EXPECTED_SHA"]
+if obj.get("version") != expected_version:
+    raise SystemExit(f"version mismatch: got={obj.get('version')} expected={expected_version}")
+if obj.get("git_sha") != expected_sha:
+    raise SystemExit(f"git_sha mismatch: got={obj.get('git_sha')} expected={expected_sha}")
+print("ok")
+PY
+
+tail_logs="$(docker logs --tail 200 "$cid" 2>&1 || true)"
+echo "$tail_logs" | grep -E "Traceback \\(most recent call last\\)|\\bFATAL\\b|\\bCRITICAL\\b" >/dev/null && {
+  echo "ERROR: fatal indicator found in recent logs" >&2
+  exit 1
+}
+
+echo "ok: verification passed"
+


### PR DESCRIPTION
- Closes #60

## Summary
- Add ORIN docker compose deployment template (`deploy/orin/compose.yaml`) pinned by `/opt/healthdelta/.env`.
- Add tag-triggered ORIN deploy workflow (`.github/workflows/deploy_backend_orin.yml`) running on `runs-on: [self-hosted, linux, orin]`.
- Add deploy/verify scripts and ORIN runbook.

## Test plan
- CI green on PR.
- Requires ORIN runner configuration to execute tag deploy (see `docs/runbook_orin_deploy.md`).