### PR TITLE
CI: issue footer check handles force-push

### DIFF
--- a/.ai/prompts/issue_99.md
+++ b/.ai/prompts/issue_99.md
@@ -1,0 +1,21 @@
+---
+Story
+As a CI operator,
+I want the Issue footer checker to tolerate force-push history rewrites,
+So that governance checks do not fail when branch history is rebased.
+
+Context / Why
+We allow rebases and force-pushes. The current check assumes the "before" SHA is still present, causing CI to fail on push events after history rewrites.
+
+Acceptance Criteria
+- Given a force-pushed branch, when CI runs the Issue footer check, then it resolves a safe commit range without crashing.
+- Given a normal push, when CI runs the Issue footer check, then it inspects the correct commit range.
+- The check continues to require an Issue footer in every commit message.
+
+Out of Scope
+- Changing policy to disallow rebases or force-pushes.
+- Altering Issue footer formatting requirements.
+
+Notes
+- Use merge-base fallbacks when the "before" SHA is missing.
+---

--- a/.ai/sessions/2026-02-01/session_1.md
+++ b/.ai/sessions/2026-02-01/session_1.md
@@ -1,0 +1,9 @@
+# Session 1 — 2026-02-01
+
+Issue: #99
+
+Goal
+- Fix Issue footer checker to handle force-push commit ranges without failing CI.
+
+Notes
+- Add tests covering push event with missing base SHA and normal ancestor case.

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -57,3 +57,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-01-30,72,,10,codex,,"Fix Issue footer checker to use merge-base for branch creation pushes"
 2026-01-30,72,,8,codex,,"Fix Issue footer checker for merge commit parent order"
 2026-01-30,72,,6,codex,,"Handle force-push ranges in Issue footer checker"
+2026-02-01,99,,30,codex,,"Handle force-push ranges in Issue footer checker"

--- a/scripts/check_issue_footer.py
+++ b/scripts/check_issue_footer.py
@@ -69,8 +69,17 @@ def _resolve_commit_range() -> list[str]:
 
     if head and base and base != "0" * 40:
         try:
+            subprocess.check_call(["git", "merge-base", "--is-ancestor", base, head])
             mb = _git("merge-base", base, head)
             commits = _git("rev-list", f"{mb}..{head}").splitlines()
+            return commits or [head]
+        except Exception:
+            pass
+
+        try:
+            main_ref = _git("rev-parse", "origin/main")
+            merge_base = _git("merge-base", head, main_ref)
+            commits = _git("rev-list", f"{merge_base}..{head}").splitlines()
             return commits or [head]
         except Exception:
             commits = _git("rev-list", f"{base}..{head}").splitlines()

--- a/tests/test_issue_footer.py
+++ b/tests/test_issue_footer.py
@@ -1,5 +1,9 @@
 import importlib.util
+import os
+import subprocess
+import unittest
 from pathlib import Path
+from unittest import mock
 
 
 def _load_module():
@@ -11,19 +15,74 @@ def _load_module():
     return module
 
 
-def test_issue_footer_present():
-    mod = _load_module()
-    msg = "Add feature X\n\nIssue: #72\n"
-    assert mod.message_has_issue_footer(msg)
+class TestIssueFooter(unittest.TestCase):
+    def test_issue_footer_present(self):
+        mod = _load_module()
+        msg = "Add feature X\n\nIssue: #72\n"
+        self.assertTrue(mod.message_has_issue_footer(msg))
+
+    def test_issue_footer_absent(self):
+        mod = _load_module()
+        msg = "Add feature X\n\nRefs #72\n"
+        self.assertFalse(mod.message_has_issue_footer(msg))
+
+    def test_issue_footer_allows_trailing_space(self):
+        mod = _load_module()
+        msg = "Fix bug\n\nIssue: #123   \n"
+        self.assertTrue(mod.message_has_issue_footer(msg))
 
 
-def test_issue_footer_absent():
-    mod = _load_module()
-    msg = "Add feature X\n\nRefs #72\n"
-    assert not mod.message_has_issue_footer(msg)
+class TestResolveCommitRange(unittest.TestCase):
+    def test_force_push_fallback(self):
+        mod = _load_module()
+
+        def fake_git(*args):
+            if args == ("rev-list", "--parents", "-n", "1", "HEAD"):
+                return "head parent"
+            if args == ("rev-parse", "origin/main"):
+                return "mainsha"
+            if args == ("merge-base", "headsha", "mainsha"):
+                return "basesha"
+            if args == ("rev-list", "basesha..headsha"):
+                return "c1\nc2"
+            raise AssertionError(f"Unexpected git call: {args}")
+
+        with mock.patch.dict(os.environ, {"GITHUB_EVENT_NAME": "push"}):
+            with mock.patch.object(
+                mod, "_load_event", return_value={"before": "badbase", "after": "headsha"}
+            ):
+                with mock.patch.object(mod, "_git", side_effect=fake_git):
+                    with mock.patch.object(
+                        mod.subprocess,
+                        "check_call",
+                        side_effect=subprocess.CalledProcessError(1, ["git"]),
+                    ):
+                        commits = mod._resolve_commit_range()
+
+        self.assertEqual(commits, ["c1", "c2"])
+
+    def test_push_ancestor(self):
+        mod = _load_module()
+
+        def fake_git(*args):
+            if args == ("rev-list", "--parents", "-n", "1", "HEAD"):
+                return "head parent"
+            if args == ("merge-base", "basesha", "headsha"):
+                return "basesha"
+            if args == ("rev-list", "basesha..headsha"):
+                return "c3\nc4"
+            raise AssertionError(f"Unexpected git call: {args}")
+
+        with mock.patch.dict(os.environ, {"GITHUB_EVENT_NAME": "push"}):
+            with mock.patch.object(
+                mod, "_load_event", return_value={"before": "basesha", "after": "headsha"}
+            ):
+                with mock.patch.object(mod, "_git", side_effect=fake_git):
+                    with mock.patch.object(mod.subprocess, "check_call", return_value=None):
+                        commits = mod._resolve_commit_range()
+
+        self.assertEqual(commits, ["c3", "c4"])
 
 
-def test_issue_footer_allows_trailing_space():
-    mod = _load_module()
-    msg = "Fix bug\n\nIssue: #123   \n"
-    assert mod.message_has_issue_footer(msg)
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle force-push commit ranges in Issue footer checker by falling back to origin/main merge-base
- add unittest coverage for force-push and ancestor push scenarios

## Testing
- python3 -m unittest tests/test_issue_footer.py -v

Issue: #99