### PR TITLE
FHIR export: MedicationStatement + MedicationDispense

### DIFF
--- a/.ai/prompts/issue_76.md
+++ b/.ai/prompts/issue_76.md
@@ -1,0 +1,17 @@
+---
+Story
+As an operator,
+I want MedicationStatement and MedicationDispense resources exported,
+So that inpatient and discharge meds are visible.
+
+Context / Why
+Current export focuses on MedicationRequest; statements/dispenses are common in patient portals.
+
+Acceptance Criteria
+- NDJSON includes MedicationStatement/MedicationDispense rows with event_time from effective[x] or whenHandedOver.
+- DuckDB supports these in medication tables or a new table with report coverage.
+- Tests cover each resource type.
+
+Out of Scope
+- Medication code normalization.
+---

--- a/.ai/sessions/2026-02-01/session_1.md
+++ b/.ai/sessions/2026-02-01/session_1.md
@@ -1,13 +1,12 @@
 # Session 1 — 2026-02-01
 
-Issue: #74
+Issue: #76
 
 Goal
-- Rebase Procedure export after Encounter merge and resolve conflicts.
+- Export MedicationStatement/MedicationDispense NDJSON and cover in tests.
 
 Notes
-- Merged Encounter + Procedure handling across NDJSON export, DuckDB loader, reporting, and tests.
-- Fixed test_ndjson_export fixture definition and validated locally.
+- Add event_time handling and include new resource types in medications stream.
 
 Local verification
 - TZ=UTC python3 -m unittest tests/test_ndjson_export.py -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -64,3 +64,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-01-30,96,,10,codex,,"Run unit tests for Issue #96 guardrail changes"
 2026-02-01,74,,30,codex,,"Rebase + conflict resolution for Procedure export; fix ndjson export test"
 2026-02-01,75,,20,codex,,"Export DiagnosticReport NDJSON with Observation linkage"
+2026-02-01,76,,20,codex,,"Export MedicationStatement/MedicationDispense"

--- a/healthdelta/ndjson_export.py
+++ b/healthdelta/ndjson_export.py
@@ -314,6 +314,25 @@ def _fhir_event_time(resource: dict) -> str | None:
         t = resource.get("authoredOn")
         if isinstance(t, str):
             return _normalize_time(t)
+    if rt == "MedicationStatement":
+        t = resource.get("effectiveDateTime")
+        if isinstance(t, str):
+            return _normalize_time(t)
+        period = resource.get("effectivePeriod")
+        if isinstance(period, dict):
+            start = period.get("start")
+            if isinstance(start, str):
+                return _normalize_time(start)
+            end = period.get("end")
+            if isinstance(end, str):
+                return _normalize_time(end)
+    if rt == "MedicationDispense":
+        t = resource.get("whenHandedOver")
+        if isinstance(t, str):
+            return _normalize_time(t)
+        t = resource.get("whenPrepared")
+        if isinstance(t, str):
+            return _normalize_time(t)
     if rt == "Condition":
         t = resource.get("recordedDate")
         if isinstance(t, str):
@@ -463,7 +482,7 @@ def _export_fhir_streams(
             base["event_key"] = _sha256_bytes(json.dumps(base, sort_keys=True, separators=(",", ":")).encode("utf-8"))
             base["record_key"] = base["event_key"]
             documents.append(base)
-        elif rt == "MedicationRequest":
+        elif rt in {"MedicationRequest", "MedicationStatement", "MedicationDispense"}:
             status = res.get("status")
             if isinstance(status, str):
                 base["status"] = status

--- a/tests/test_ndjson_export.py
+++ b/tests/test_ndjson_export.py
@@ -39,6 +39,20 @@ FHIR_MED = {
     "subject": {"reference": "Patient/p1"},
     "authoredOn": "2020-01-03T00:00:00Z",
 }
+FHIR_MED_STATEMENT = {
+    "resourceType": "MedicationStatement",
+    "id": "ms1",
+    "status": "active",
+    "subject": {"reference": "Patient/p1"},
+    "effectiveDateTime": "2020-01-03T06:00:00Z",
+}
+FHIR_MED_DISPENSE = {
+    "resourceType": "MedicationDispense",
+    "id": "md1",
+    "status": "completed",
+    "subject": {"reference": "Patient/p1"},
+    "whenHandedOver": "2020-01-03T12:00:00Z",
+}
 FHIR_COND = {
     "resourceType": "Condition",
     "id": "c1",
@@ -145,6 +159,8 @@ class TestNdjsonExport(unittest.TestCase):
             _write_json(clinical_dir / "obs.json", FHIR_OBS)
             _write_json(clinical_dir / "doc.json", FHIR_DOC)
             _write_json(clinical_dir / "med.json", FHIR_MED)
+            _write_json(clinical_dir / "med_statement.json", FHIR_MED_STATEMENT)
+            _write_json(clinical_dir / "med_dispense.json", FHIR_MED_DISPENSE)
             _write_json(clinical_dir / "cond.json", FHIR_COND)
             _write_json(clinical_dir / "encounter.json", FHIR_ENCOUNTER)
             _write_json(clinical_dir / "procedure.json", FHIR_PROC)
@@ -223,7 +239,7 @@ class TestNdjsonExport(unittest.TestCase):
             # HealthKit Record (1) + FHIR Observation (1) + CDA observation-like entry (1)
             self.assertEqual(len(observations), 3)
             self.assertEqual(len(documents), 1)
-            self.assertEqual(len(meds), 1)
+            self.assertEqual(len(meds), 3)
             self.assertEqual(len(conds), 1)
             self.assertEqual(len(encounters), 1)
             self.assertEqual(len(procedures), 1)
@@ -244,6 +260,11 @@ class TestNdjsonExport(unittest.TestCase):
             obs_key = fhir_obs[0].get("record_key")
             self.assertIn(obs_key, report_by_id["DiagnosticReport/dr1"].get("result_observation_record_keys", []))
             self.assertNotIn("result_observation_record_keys", report_by_id["DiagnosticReport/dr2"])
+            med_types = {m.get("resource_type") for m in meds}
+            self.assertEqual(
+                med_types,
+                {"MedicationRequest", "MedicationStatement", "MedicationDispense"},
+            )
 
             combined = "".join(p.read_text(encoding="utf-8") for p in expected_files)
             self.assertNotIn("John Doe", combined)


### PR DESCRIPTION
## Summary
- export MedicationStatement and MedicationDispense as medication NDJSON rows
- add event_time handling for effective[x]/whenHandedOver
- extend NDJSON export tests for new resource types

## Testing
- TZ=UTC python3 -m unittest tests/test_ndjson_export.py -v

Issue: #76