### PR TITLE
Identity: subject.identifier resolution

### DIFF
--- a/.ai/prompts/issue_78.md
+++ b/.ai/prompts/issue_78.md
@@ -1,0 +1,17 @@
+---
+Story
+As a maintainer,
+I want subject resolution to recognize subject.identifier and Patient.identifier mappings,
+So that multi-system linkage improves without PII.
+
+Context / Why
+Epic/MyChart data often uses identifier systems rather than Patient/<id> references.
+
+Acceptance Criteria
+- Given FHIR resources with subject.identifier, identity resolution matches to known Patient identifiers when available.
+- Deterministic behavior when multiple candidates exist (choose "unresolved" unless unambiguous).
+- Tests for subject.identifier and fallback logic.
+
+Out of Scope
+- Probabilistic matching.
+---

--- a/.ai/sessions/2026-02-01/session_3.md
+++ b/.ai/sessions/2026-02-01/session_3.md
@@ -1,0 +1,14 @@
+# Session 3 — 2026-02-01
+
+Issue: #78
+
+Goal
+- Resolve canonical person mapping from FHIR subject/patient identifier references.
+
+Notes
+- Add deterministic candidate resolution: if multiple mapped people are found, mark unresolved.
+- Keep existing fallback to subject reference/default mapping when no identifier mappings are found.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_ndjson_export.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -66,3 +66,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,75,,20,codex,,"Export DiagnosticReport NDJSON with Observation linkage"
 2026-02-01,76,,20,codex,,"Export MedicationStatement/MedicationDispense"
 2026-02-01,77,,20,codex,,"Export AllergyIntolerance + Immunization"
+2026-02-01,78,,25,codex,,"subject.identifier and patient.identifier resolution with ambiguity guard"

--- a/healthdelta/ndjson_export.py
+++ b/healthdelta/ndjson_export.py
@@ -222,6 +222,62 @@ def _extract_fhir_subject_patient_id(resource: dict) -> str | None:
     return None
 
 
+def _extract_identifier_pairs(value: Any) -> list[tuple[str, str]]:
+    items = value if isinstance(value, list) else [value]
+    pairs: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        system = item.get("system")
+        ident_value = item.get("value")
+        if not (isinstance(system, str) and isinstance(ident_value, str)):
+            continue
+        system = system.strip()
+        ident_value = ident_value.strip()
+        if not system or not ident_value:
+            continue
+        pair = (system, ident_value)
+        if pair not in seen:
+            seen.add(pair)
+            pairs.append(pair)
+    return pairs
+
+
+def _extract_fhir_reference_identifier_pairs(resource: dict) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for key in ("subject", "patient"):
+        ref = resource.get(key)
+        if not isinstance(ref, dict):
+            continue
+        ident = ref.get("identifier")
+        pairs.extend(_extract_identifier_pairs(ident))
+    return pairs
+
+
+def _resolve_fhir_person_id(ctx: ExportContext, resource: dict) -> str:
+    candidates: set[str] = set()
+    subject_patient_id = _extract_fhir_subject_patient_id(resource)
+    if subject_patient_id:
+        mapped = ctx.patient_id_map.get(("fhir:id", subject_patient_id))
+        if isinstance(mapped, str):
+            candidates.add(mapped)
+
+    for system, value in _extract_fhir_reference_identifier_pairs(resource):
+        mapped = ctx.patient_id_map.get((system, value))
+        if isinstance(mapped, str):
+            candidates.add(mapped)
+
+    if len(candidates) == 1:
+        return next(iter(candidates))
+    if len(candidates) > 1:
+        return "unresolved"
+
+    if subject_patient_id:
+        return _canonical_person_id(ctx, system="fhir:id", value=subject_patient_id)
+    return _canonical_person_id(ctx)
+
+
 def _extract_fhir_reference_id(ref: str, resource_type: str) -> str | None:
     if not isinstance(ref, str) or not ref.strip():
         return None
@@ -435,8 +491,7 @@ def _export_fhir_streams(
             continue
 
         rid = res.get("id") if isinstance(res.get("id"), str) else None
-        subject_patient_id = _extract_fhir_subject_patient_id(res)
-        person = _canonical_person_id(ctx, system="fhir:id", value=subject_patient_id) if subject_patient_id else _canonical_person_id(ctx)
+        person = _resolve_fhir_person_id(ctx, res)
         event_time = _fhir_event_time(res)
 
         base = {

--- a/tests/test_ndjson_export.py
+++ b/tests/test_ndjson_export.py
@@ -158,6 +158,135 @@ def _read_ndjson(path: Path) -> list[dict]:
 
 
 class TestNdjsonExport(unittest.TestCase):
+    def test_export_ndjson_resolves_subject_and_patient_identifier_mappings(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "out"
+            run_dir = base / "staging" / "run-1"
+            clinical_dir = run_dir / "source" / "clinical-records"
+            clinical_dir.mkdir(parents=True, exist_ok=True)
+
+            layout = {
+                "run_id": "run-1",
+                "clinical_json": [
+                    "source/clinical-records/obs_subject_identifier.json",
+                    "source/clinical-records/obs_reference_fallback.json",
+                    "source/clinical-records/obs_ambiguous.json",
+                    "source/clinical-records/immunization_patient_identifier.json",
+                ],
+            }
+            _write_json(run_dir / "layout.json", layout)
+
+            _write_json(
+                clinical_dir / "obs_subject_identifier.json",
+                {
+                    "resourceType": "Observation",
+                    "id": "o-subject",
+                    "status": "final",
+                    "subject": {"identifier": {"system": "urn:mrn", "value": "111"}},
+                    "effectiveDateTime": "2020-01-01T00:00:00Z",
+                },
+            )
+            _write_json(
+                clinical_dir / "obs_reference_fallback.json",
+                {
+                    "resourceType": "Observation",
+                    "id": "o-fallback",
+                    "status": "final",
+                    "subject": {
+                        "reference": "Patient/p1",
+                        "identifier": {"system": "urn:mrn", "value": "unmapped"},
+                    },
+                    "effectiveDateTime": "2020-01-01T01:00:00Z",
+                },
+            )
+            _write_json(
+                clinical_dir / "obs_ambiguous.json",
+                {
+                    "resourceType": "Observation",
+                    "id": "o-ambiguous",
+                    "status": "final",
+                    "subject": {
+                        "reference": "Patient/p1",
+                        "identifier": {"system": "urn:mrn", "value": "222"},
+                    },
+                    "effectiveDateTime": "2020-01-01T02:00:00Z",
+                },
+            )
+            _write_json(
+                clinical_dir / "immunization_patient_identifier.json",
+                {
+                    "resourceType": "Immunization",
+                    "id": "i-subject",
+                    "status": "completed",
+                    "patient": {"identifier": {"system": "urn:mrn", "value": "111"}},
+                    "occurrenceDateTime": "2020-01-01T03:00:00Z",
+                },
+            )
+
+            identity = base / "identity"
+            identity.mkdir(parents=True, exist_ok=True)
+            _write_json(
+                identity / "people.json",
+                {
+                    "people": [
+                        {"person_key": "person-a"},
+                        {"person_key": "person-b"},
+                    ]
+                },
+            )
+            _write_json(
+                identity / "aliases.json",
+                {
+                    "aliases": [
+                        {
+                            "person_key": "person-a",
+                            "source": {
+                                "external_ids": [
+                                    {"system": "fhir:id", "value": "p1"},
+                                    {"system": "urn:mrn", "value": "111"},
+                                ]
+                            },
+                        },
+                        {
+                            "person_key": "person-b",
+                            "source": {
+                                "external_ids": [
+                                    {"system": "urn:mrn", "value": "222"},
+                                ]
+                            },
+                        },
+                    ]
+                },
+            )
+
+            out_local = root / "ndjson_local"
+            run = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "healthdelta",
+                    "export",
+                    "ndjson",
+                    "--input",
+                    str(run_dir),
+                    "--out",
+                    str(out_local),
+                    "--mode",
+                    "local",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(run.returncode, 0, msg=f"stdout={run.stdout}\nstderr={run.stderr}")
+
+            observations = _read_ndjson(out_local / "observations.ndjson")
+            by_source_id = {r.get("source_id"): r for r in observations if isinstance(r, dict)}
+            self.assertEqual(by_source_id["Observation/o-subject"]["canonical_person_id"], "person-a")
+            self.assertEqual(by_source_id["Observation/o-fallback"]["canonical_person_id"], "person-a")
+            self.assertEqual(by_source_id["Observation/o-ambiguous"]["canonical_person_id"], "unresolved")
+            self.assertEqual(by_source_id["Immunization/i-subject"]["canonical_person_id"], "person-a")
+
     def test_export_ndjson_local_and_share_are_deterministic_and_pii_free(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
Issue: #78

Implements identity resolution for FHIR `subject.identifier` and `patient.identifier` mappings.

## What changed
- Added deterministic person resolution for FHIR resources using:
  - `subject.reference` / `patient.reference` (existing `fhir:id` mapping)
  - `subject.identifier` and `patient.identifier` mappings from identity aliases
- If multiple mapped candidates are found for a resource, exporter now emits `canonical_person_id: unresolved`.
- Added focused test coverage for:
  - unambiguous subject identifier mapping
  - fallback to subject reference mapping when identifier is unmapped
  - ambiguous mappings resolving to `unresolved`
  - patient identifier mapping on Immunization

## Validation
- `TZ=UTC python3 -m unittest tests/test_ndjson_export.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #78
