### PR TITLE
De-id: scrub FHIR free-text/narrative

### DIFF
--- a/.ai/prompts/issue_80.md
+++ b/.ai/prompts/issue_80.md
@@ -1,0 +1,17 @@
+---
+Story
+As a maintainer,
+I want de-identification to scrub free-text fields in FHIR resources,
+So that narrative strings don’t leak PHI in share-safe outputs.
+
+Context / Why
+Narrative text can contain names or identifiers.
+
+Acceptance Criteria
+- For supported FHIR resource types, text/narrative fields are replaced with a deterministic placeholder.
+- No regression in schema validation.
+- Tests prove text fields are redacted.
+
+Out of Scope
+- NLP-based PII detection.
+---

--- a/.ai/sessions/2026-02-01/session_5.md
+++ b/.ai/sessions/2026-02-01/session_5.md
@@ -1,0 +1,14 @@
+# Session 5 — 2026-02-01
+
+Issue: #80
+
+Goal
+- Redact FHIR narrative/free-text fields with deterministic placeholders during de-identification.
+
+Notes
+- Added supported resource-type gating and deterministic placeholder replacement for narrative and note/comment fields.
+- Extended de-id tests to validate `comments`, `text.div`, and `note[].text` redaction.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_deid.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -68,3 +68,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,77,,20,codex,,"Export AllergyIntolerance + Immunization"
 2026-02-01,78,,25,codex,,"subject.identifier and patient.identifier resolution with ambiguity guard"
 2026-02-01,79,,20,codex,,"unresolved reference integrity report outputs and tests"
+2026-02-01,80,,20,codex,,"de-id free-text narrative redaction for FHIR resources"

--- a/healthdelta/deid.py
+++ b/healthdelta/deid.py
@@ -30,6 +30,29 @@ def _read_json(path: Path) -> Any:
 
 
 _WS_RE = re.compile(r"\s+")
+FHIR_TEXT_PLACEHOLDER = "[REDACTED_TEXT]"
+FHIR_FREE_TEXT_RESOURCE_TYPES = {
+    "AllergyIntolerance",
+    "Condition",
+    "DiagnosticReport",
+    "DocumentReference",
+    "Encounter",
+    "Immunization",
+    "MedicationDispense",
+    "MedicationRequest",
+    "MedicationStatement",
+    "Observation",
+    "Procedure",
+}
+FHIR_FREE_TEXT_KEYS = {
+    "comments",
+    "conclusion",
+    "description",
+    "display",
+    "instructions",
+    "title",
+    "valueString",
+}
 
 
 def _collapse_ws(s: str) -> str:
@@ -134,8 +157,48 @@ def _deep_replace_strings(obj: Any, *, people: list[PersonPseudonym]) -> Any:
     return obj
 
 
+def _redact_fhir_free_text(obj: Any) -> Any:
+    if isinstance(obj, list):
+        return [_redact_fhir_free_text(v) for v in obj]
+    if isinstance(obj, dict):
+        out: dict[str, Any] = {}
+        for key, value in obj.items():
+            if key in FHIR_FREE_TEXT_KEYS and isinstance(value, str):
+                out[key] = FHIR_TEXT_PLACEHOLDER
+                continue
+            if key == "text" and isinstance(value, dict):
+                # Keep narrative status while redacting XHTML/string payload.
+                status = value.get("status")
+                out[key] = {
+                    "status": status if isinstance(status, str) else "generated",
+                    "div": FHIR_TEXT_PLACEHOLDER,
+                }
+                continue
+            if key == "note" and isinstance(value, list):
+                notes: list[Any] = []
+                for item in value:
+                    if isinstance(item, dict):
+                        redacted = dict(item)
+                        if isinstance(redacted.get("text"), str):
+                            redacted["text"] = FHIR_TEXT_PLACEHOLDER
+                        notes.append(_redact_fhir_free_text(redacted))
+                    elif isinstance(item, str):
+                        notes.append(FHIR_TEXT_PLACEHOLDER)
+                    else:
+                        notes.append(_redact_fhir_free_text(item))
+                out[key] = notes
+                continue
+            out[key] = _redact_fhir_free_text(value)
+        return out
+    return obj
+
+
 def _deid_fhir_json(obj: Any, people: list[PersonPseudonym]) -> Any:
     obj = _deep_replace_strings(obj, people=people)
+    if isinstance(obj, dict):
+        rt = obj.get("resourceType")
+        if isinstance(rt, str) and rt in FHIR_FREE_TEXT_RESOURCE_TYPES:
+            obj = _redact_fhir_free_text(obj)
     if isinstance(obj, dict) and obj.get("resourceType") == "Patient":
         names = obj.get("name")
         if isinstance(names, list):

--- a/tests/test_deid.py
+++ b/tests/test_deid.py
@@ -38,6 +38,9 @@ SYNTH_FHIR_OBS = {
     "resourceType": "Observation",
     "id": "o1",
     "subject": {"display": "John Doe"},
+    "comments": "Patient John Doe reported chest pain at Mercy Hospital.",
+    "text": {"status": "generated", "div": "<div>John Doe narrative</div>"},
+    "note": [{"text": "John Doe says he feels better today."}],
 }
 
 
@@ -114,6 +117,11 @@ class TestDeid(unittest.TestCase):
             self.assertNotIn("Doe, John", all_text)
             self.assertNotIn("19800102", all_text)  # CDA birthTime
             self.assertNotIn("1980-01-02", all_text)  # FHIR birthDate
+
+            obs_obj = json.loads((out_dir / obs_rel).read_text(encoding="utf-8"))
+            self.assertEqual(obs_obj.get("comments"), "[REDACTED_TEXT]")
+            self.assertEqual(obs_obj.get("text"), {"status": "generated", "div": "[REDACTED_TEXT]"})
+            self.assertEqual(obs_obj.get("note"), [{"text": "[REDACTED_TEXT]"}])
 
             # Determinism: running again yields identical mapping and identical deid export.xml bytes
             out_dir_2 = root / "data" / "deid" / "run123_2"


### PR DESCRIPTION
Issue: #80

Implements deterministic free-text narrative scrubbing for supported FHIR resource types during de-identification.

## What changed
- Added deterministic placeholder redaction (`[REDACTED_TEXT]`) for FHIR narrative/free-text fields on supported resource types.
- Redaction now covers:
  - narrative `text` blocks (`status` preserved, `div` redacted)
  - `note[].text`
  - common free-text keys such as `comments`, `description`, `conclusion`, `instructions`, `display`, and `valueString`
- Extended de-id tests to validate free-text redaction while preserving existing name/DOB redaction behavior.

## Validation
- `TZ=UTC python3 -m unittest tests/test_deid.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #80
