### PR TITLE
CDA export: discharge summary coverage

### DIFF
--- a/.ai/prompts/issue_81.md
+++ b/.ai/prompts/issue_81.md
@@ -1,0 +1,17 @@
+---
+Story
+As an operator,
+I want CDA parsing to cover discharge summary headers and key sections,
+So that hospital documents add structured timeline context.
+
+Context / Why
+CDA often includes discharge summaries and problems not in FHIR JSON.
+
+Acceptance Criteria
+- CDA parsing includes additional observation-like and encounter-like entries (share-safe).
+- NDJSON export remains deterministic and validated.
+- Tests cover at least two new CDA sections.
+
+Out of Scope
+- Full CDA narrative text extraction.
+---

--- a/.ai/sessions/2026-02-01/session_6.md
+++ b/.ai/sessions/2026-02-01/session_6.md
@@ -1,0 +1,15 @@
+# Session 6 — 2026-02-01
+
+Issue: #81
+
+Goal
+- Extend CDA parsing to include discharge summary section context and encounter timing rows.
+
+Notes
+- Added CDA section-level and observation-level rows with section metadata.
+- Added encounter-like rows from `encompassingEncounter/serviceEvent` effectiveTime values.
+- Added NDJSON export test fixture covering Problem List + Discharge Summary sections.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_ndjson_export.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -69,3 +69,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,78,,25,codex,,"subject.identifier and patient.identifier resolution with ambiguity guard"
 2026-02-01,79,,20,codex,,"unresolved reference integrity report outputs and tests"
 2026-02-01,80,,20,codex,,"de-id free-text narrative redaction for FHIR resources"
+2026-02-01,81,,20,codex,,"CDA discharge sections and encounter timing coverage"

--- a/healthdelta/ndjson_export.py
+++ b/healthdelta/ndjson_export.py
@@ -701,62 +701,141 @@ def _export_fhir_streams(
     return observations, documents, meds, conds, encounters, procedures, diagnostic_reports
 
 
-def _export_cda_observations(ctx: ExportContext) -> list[dict]:
+def _xml_child_text(el: ET.Element, name: str) -> str | None:
+    for child in list(el):
+        if _localname(child.tag) != name:
+            continue
+        text = "".join(child.itertext()).strip()
+        if text:
+            return text
+    return None
+
+
+def _xml_child_attr(el: ET.Element, name: str, attr: str) -> str | None:
+    for child in list(el):
+        if _localname(child.tag) == name:
+            value = child.attrib.get(attr)
+            if isinstance(value, str) and value.strip():
+                return value
+    return None
+
+
+def _cda_effective_start_end(el: ET.Element) -> tuple[str | None, str | None]:
+    for child in list(el):
+        if _localname(child.tag) != "effectiveTime":
+            continue
+        direct_value = child.attrib.get("value")
+        if isinstance(direct_value, str) and direct_value.strip():
+            t = _normalize_time(direct_value)
+            return t, t
+        low = None
+        high = None
+        for grand in list(child):
+            ln = _localname(grand.tag)
+            v = grand.attrib.get("value")
+            if not isinstance(v, str):
+                continue
+            if ln == "low":
+                low = _normalize_time(v)
+            elif ln == "high":
+                high = _normalize_time(v)
+        return low, high
+    return None, None
+
+
+def _export_cda_streams(ctx: ExportContext) -> tuple[list[dict], list[dict]]:
     if not ctx.export_cda_rel:
-        return []
+        return [], []
     path = ctx.root_dir / ctx.export_cda_rel
     if not path.exists():
-        return []
+        return [], []
 
     observations: list[dict] = []
-    task = progress.task("Parse export_cda.xml observations", total=None, unit="rows")
-    batch = 0
-    for _, el in ET.iterparse(path, events=("end",)):
-        if _localname(el.tag) != "observation":
-            continue
+    encounters: list[dict] = []
 
-        effective_time = None
-        code_code = None
-        code_display = None
-        value_val = None
-        value_unit = None
+    root = ET.parse(path).getroot()
 
-        for child in list(el):
-            ln = _localname(child.tag)
-            if ln == "effectiveTime":
-                v = child.attrib.get("value")
-                if isinstance(v, str):
-                    effective_time = _normalize_time(v)
-            elif ln == "code":
-                code_code = child.attrib.get("code")
-                code_display = child.attrib.get("displayName")
-            elif ln == "value":
-                value_val = child.attrib.get("value")
-                value_unit = child.attrib.get("unit")
+    # Section-level rows provide deterministic, share-safe discharge summary context.
+    sections = [el for el in root.iter() if _localname(el.tag) == "section"]
+    task_sections = progress.task("Parse export_cda.xml sections", total=len(sections), unit="sections")
+    for section in sections:
+        section_code = _xml_child_attr(section, "code", "code")
+        section_display = _xml_child_attr(section, "code", "displayName")
+        section_title = _xml_child_text(section, "title")
+        section_time = _normalize_time(_xml_child_attr(section, "effectiveTime", "value"))
 
-        base = {
-            "schema_version": 2,
-            "canonical_person_id": _canonical_person_id(ctx),
-            "source": "cda",
-            "source_file": _safe_relpath(ctx.export_cda_rel),
-            "event_time": effective_time,
-            "run_id": ctx.run_id,
-            "code": code_code,
-            "value": value_val,
-            "unit": value_unit,
-        }
-        base["event_key"] = _sha256_bytes(json.dumps(base, sort_keys=True, separators=(",", ":")).encode("utf-8"))
-        base["record_key"] = base["event_key"]
-        observations.append(base)
-        el.clear()
-        batch += 1
-        if batch >= 500:
-            task.advance(batch)
-            batch = 0
+        if section_code or section_title or section_display:
+            base = {
+                "schema_version": 2,
+                "canonical_person_id": _canonical_person_id(ctx),
+                "source": "cda",
+                "source_file": _safe_relpath(ctx.export_cda_rel),
+                "event_time": section_time,
+                "run_id": ctx.run_id,
+                "resource_type": "CDASection",
+                "section_code": section_code,
+                "section_display": section_display,
+                "section_title": section_title,
+            }
+            base["event_key"] = _sha256_bytes(json.dumps(base, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+            base["record_key"] = base["event_key"]
+            observations.append(base)
 
-    if batch:
-        task.advance(batch)
-    return observations
+        for observation in [el for el in section.iter() if _localname(el.tag) == "observation"]:
+            effective_time = _normalize_time(_xml_child_attr(observation, "effectiveTime", "value"))
+            code_code = _xml_child_attr(observation, "code", "code")
+            code_display = _xml_child_attr(observation, "code", "displayName")
+            value_val = _xml_child_attr(observation, "value", "value")
+            value_unit = _xml_child_attr(observation, "value", "unit")
+
+            base = {
+                "schema_version": 2,
+                "canonical_person_id": _canonical_person_id(ctx),
+                "source": "cda",
+                "source_file": _safe_relpath(ctx.export_cda_rel),
+                "event_time": effective_time,
+                "run_id": ctx.run_id,
+                "resource_type": "CDAObservation",
+                "section_code": section_code,
+                "section_display": section_display,
+                "section_title": section_title,
+                "code": code_code,
+                "value": value_val,
+                "unit": value_unit,
+            }
+            base["event_key"] = _sha256_bytes(json.dumps(base, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+            base["record_key"] = base["event_key"]
+            observations.append(base)
+        task_sections.advance(1)
+
+    # Encounter-like rows from discharge/service-event timing.
+    encounter_like = [
+        el
+        for el in root.iter()
+        if _localname(el.tag) in {"encompassingEncounter", "serviceEvent"}
+    ]
+    task_enc = progress.task("Parse export_cda.xml encounter timing", total=len(encounter_like), unit="rows")
+    for el in encounter_like:
+        start, end = _cda_effective_start_end(el)
+        event_time = start or end
+        if event_time:
+            base = {
+                "schema_version": 2,
+                "canonical_person_id": _canonical_person_id(ctx),
+                "source": "cda",
+                "source_file": _safe_relpath(ctx.export_cda_rel),
+                "event_time": event_time,
+                "run_id": ctx.run_id,
+                "resource_type": "CDAEncounter",
+                "start_time": start,
+                "end_time": end,
+            }
+            base["event_key"] = _sha256_bytes(json.dumps(base, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+            base["record_key"] = base["event_key"]
+            encounters.append(base)
+        task_enc.advance(1)
+
+    return observations, encounters
 
 
 def export_ndjson(*, input_dir: str, out_dir: str, mode: str = "local") -> None:
@@ -776,13 +855,13 @@ def export_ndjson(*, input_dir: str, out_dir: str, mode: str = "local") -> None:
             fhir_reports,
         ) = _export_fhir_streams(ctx)
     with progress.phase("export: parse CDA"):
-        cda_obs = _export_cda_observations(ctx)
+        cda_obs, cda_encounters = _export_cda_streams(ctx)
 
     observations = [*healthkit_obs, *fhir_obs, *cda_obs]
     documents = [*fhir_docs]
     meds = [*fhir_meds]
     conds = [*fhir_conds]
-    encounters = [*fhir_encounters]
+    encounters = [*fhir_encounters, *cda_encounters]
     procedures = [*fhir_procedures]
     diagnostic_reports = [*fhir_reports]
 

--- a/tests/test_ndjson_export.py
+++ b/tests/test_ndjson_export.py
@@ -141,6 +141,49 @@ EXPORT_CDA_XML = """<?xml version="1.0" encoding="UTF-8"?>
 </ClinicalDocument>
 """
 
+EXPORT_CDA_DISCHARGE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3">
+  <componentOf>
+    <encompassingEncounter>
+      <effectiveTime>
+        <low value="20200110120000"/>
+        <high value="20200111103000"/>
+      </effectiveTime>
+    </encompassingEncounter>
+  </componentOf>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <code code="11450-4" displayName="Problem List"/>
+          <title>Problem List</title>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <effectiveTime value="20200110130000"/>
+              <code code="75326-9" displayName="Problem"/>
+              <value xsi:type="ST" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" value="Hypertension"/>
+            </observation>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+          <code code="18842-5" displayName="Discharge Summary"/>
+          <title>Discharge Summary</title>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <effectiveTime value="20200111100000"/>
+              <code code="34109-9" displayName="Discharge diagnosis"/>
+              <value xsi:type="ST" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" value="Recovered"/>
+            </observation>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>
+"""
+
 
 def _write_json(path: Path, obj: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -158,6 +201,57 @@ def _read_ndjson(path: Path) -> list[dict]:
 
 
 class TestNdjsonExport(unittest.TestCase):
+    def test_export_ndjson_cda_discharge_sections_and_encounter_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            run_dir = root / "staging" / "run-cda"
+            cda_rel = "source/unpacked/export_cda.xml"
+            (run_dir / "source" / "unpacked").mkdir(parents=True, exist_ok=True)
+            (run_dir / cda_rel).write_text(EXPORT_CDA_DISCHARGE_XML, encoding="utf-8")
+
+            _write_json(
+                run_dir / "layout.json",
+                {
+                    "run_id": "run-cda",
+                    "export_cda_xml": cda_rel,
+                    "clinical_json": [],
+                },
+            )
+
+            out_local = root / "ndjson_local"
+            run = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "healthdelta",
+                    "export",
+                    "ndjson",
+                    "--input",
+                    str(run_dir),
+                    "--out",
+                    str(out_local),
+                    "--mode",
+                    "local",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(run.returncode, 0, msg=f"stdout={run.stdout}\nstderr={run.stderr}")
+
+            observations = _read_ndjson(out_local / "observations.ndjson")
+            encounters = _read_ndjson(out_local / "encounters.ndjson")
+
+            section_rows = [r for r in observations if r.get("resource_type") == "CDASection"]
+            self.assertEqual(len(section_rows), 2)
+            self.assertEqual({r.get("section_code") for r in section_rows}, {"11450-4", "18842-5"})
+
+            observation_rows = [r for r in observations if r.get("resource_type") == "CDAObservation"]
+            self.assertGreaterEqual(len(observation_rows), 2)
+
+            encounter_rows = [r for r in encounters if r.get("resource_type") == "CDAEncounter"]
+            self.assertEqual(len(encounter_rows), 1)
+            self.assertEqual(encounter_rows[0].get("event_time"), "2020-01-10T12:00:00Z")
+
     def test_export_ndjson_resolves_subject_and_patient_identifier_mappings(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
Issue: #81

Expands CDA export coverage for discharge summary content.

## What changed
- Replaced CDA-only observation parser with a broader CDA stream parser that emits:
  - section-level observation-like rows (`resource_type: CDASection`)
  - section observation rows (`resource_type: CDAObservation`)
  - encounter-like rows from discharge/service timing (`resource_type: CDAEncounter`)
- Included section metadata (`section_code`, `section_display`, `section_title`) in CDA-derived rows.
- Added test coverage for two CDA sections (Problem List + Discharge Summary) and encounter timing extraction.

## Validation
- `TZ=UTC python3 -m unittest tests/test_ndjson_export.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #81
