### PR TITLE
NDJSON: JSON schema + CI validation

### DIFF
--- a/.ai/prompts/issue_82.md
+++ b/.ai/prompts/issue_82.md
@@ -1,0 +1,17 @@
+---
+Story
+As a maintainer,
+I want a formal JSON schema for NDJSON records with versioning,
+So that compatibility and validation are enforced in CI.
+
+Context / Why
+New resource coverage increases schema complexity.
+
+Acceptance Criteria
+- A JSON schema exists for each NDJSON stream, versioned and validated in CI.
+- ndjson validate enforces schema version compatibility.
+- Tests cover invalid schema detection.
+
+Out of Scope
+- Backward conversion tools.
+---

--- a/.ai/sessions/2026-02-01/session_7.md
+++ b/.ai/sessions/2026-02-01/session_7.md
@@ -1,0 +1,15 @@
+# Session 7 — 2026-02-01
+
+Issue: #82
+
+Goal
+- Add versioned NDJSON stream schemas and enforce schema compatibility in validator logic.
+
+Notes
+- Added per-stream JSON schema files under `schemas/ndjson/v2/`.
+- Validator now resolves stream+version schemas and fails on incompatible schema versions.
+- Added tests for schema file presence and invalid schema version detection.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_ndjson_validate.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -70,3 +70,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,79,,20,codex,,"unresolved reference integrity report outputs and tests"
 2026-02-01,80,,20,codex,,"de-id free-text narrative redaction for FHIR resources"
 2026-02-01,81,,20,codex,,"CDA discharge sections and encounter timing coverage"
+2026-02-01,82,,20,codex,,"versioned NDJSON schemas and validator compatibility checks"

--- a/healthdelta/ndjson_validate.py
+++ b/healthdelta/ndjson_validate.py
@@ -9,6 +9,7 @@ from healthdelta.progress import progress
 
 
 BASE_REQUIRED_KEYS: tuple[str, ...] = ("canonical_person_id", "source", "source_file", "event_time", "run_id", "record_key")
+SCHEMA_ROOT = Path(__file__).resolve().parent.parent / "schemas" / "ndjson"
 
 
 @dataclass(frozen=True)
@@ -27,6 +28,69 @@ def _iter_ndjson_files(root: Path) -> list[Path]:
     return sorted(files, key=lambda p: p.relative_to(root).as_posix())
 
 
+def _stream_name(rel_path: str) -> str:
+    return Path(rel_path).stem
+
+
+def _validate_by_schema(
+    *,
+    rel_path: str,
+    line_no: int,
+    obj: dict,
+    schema_cache: dict[tuple[str, int], dict | None],
+) -> list[ValidationError]:
+    errs: list[ValidationError] = []
+    stream = _stream_name(rel_path)
+    schema_version = obj.get("schema_version")
+    if not isinstance(schema_version, int):
+        return errs
+
+    key = (stream, schema_version)
+    schema = schema_cache.get(key)
+    if key not in schema_cache:
+        schema_path = SCHEMA_ROOT / f"v{schema_version}" / f"{stream}.schema.json"
+        if schema_path.exists():
+            try:
+                loaded = json.loads(schema_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                loaded = None
+            schema_cache[key] = loaded if isinstance(loaded, dict) else None
+        else:
+            schema_cache[key] = None
+    schema = schema_cache.get(key)
+
+    if schema is None:
+        errs.append(
+            ValidationError(
+                rel_path=rel_path,
+                line_no=line_no,
+                code="schema_version_incompatible",
+                message=f"no schema for stream={stream!r} schema_version={schema_version}",
+            )
+        )
+        return errs
+
+    required = schema.get("required")
+    if isinstance(required, list):
+        for k in required:
+            if isinstance(k, str) and k not in obj:
+                errs.append(
+                    ValidationError(rel_path=rel_path, line_no=line_no, code="missing_required_key", message=f"missing required key: {k}")
+                )
+
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        for k, spec in properties.items():
+            if k not in obj or not isinstance(spec, dict):
+                continue
+            t = spec.get("type")
+            if t == "string" and not isinstance(obj[k], str):
+                errs.append(ValidationError(rel_path=rel_path, line_no=line_no, code="invalid_type", message=f"key {k} must be a string"))
+            if t == "integer" and not isinstance(obj[k], int):
+                errs.append(ValidationError(rel_path=rel_path, line_no=line_no, code="invalid_type", message=f"key {k} must be an integer"))
+    return errs
+
+
 def validate_ndjson_dir(
     *,
     input_dir: str,
@@ -43,6 +107,7 @@ def validate_ndjson_dir(
         return [ValidationError(rel_path=".", line_no=0, code="no_ndjson_files", message="no *.ndjson files found under input_dir")]
 
     errors: list[ValidationError] = []
+    schema_cache: dict[tuple[str, int], dict | None] = {}
 
     with progress.phase("validate: ndjson"):
         task_files = progress.task("validate: files", total=len(files), unit="files")
@@ -116,6 +181,10 @@ def validate_ndjson_dir(
                     elif not isinstance(obj.get("schema_version"), int):
                         errors.append(
                             ValidationError(rel_path=rel, line_no=line_no, code="invalid_type", message="key schema_version must be an integer")
+                        )
+                    else:
+                        errors.extend(
+                            _validate_by_schema(rel_path=rel, line_no=line_no, obj=obj, schema_cache=schema_cache)
                         )
 
                     batch += 1

--- a/schemas/ndjson/v2/conditions.schema.json
+++ b/schemas/ndjson/v2/conditions.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HealthDelta NDJSON Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "record_key",
+    "canonical_person_id",
+    "source",
+    "source_file",
+    "event_time",
+    "run_id"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 2 },
+    "record_key": { "type": "string" },
+    "canonical_person_id": { "type": "string" },
+    "source": { "type": "string" },
+    "source_file": { "type": "string" },
+    "event_time": { "type": "string" },
+    "run_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/ndjson/v2/diagnostic_reports.schema.json
+++ b/schemas/ndjson/v2/diagnostic_reports.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HealthDelta NDJSON Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "record_key",
+    "canonical_person_id",
+    "source",
+    "source_file",
+    "event_time",
+    "run_id"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 2 },
+    "record_key": { "type": "string" },
+    "canonical_person_id": { "type": "string" },
+    "source": { "type": "string" },
+    "source_file": { "type": "string" },
+    "event_time": { "type": "string" },
+    "run_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/ndjson/v2/documents.schema.json
+++ b/schemas/ndjson/v2/documents.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HealthDelta NDJSON Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "record_key",
+    "canonical_person_id",
+    "source",
+    "source_file",
+    "event_time",
+    "run_id"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 2 },
+    "record_key": { "type": "string" },
+    "canonical_person_id": { "type": "string" },
+    "source": { "type": "string" },
+    "source_file": { "type": "string" },
+    "event_time": { "type": "string" },
+    "run_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/ndjson/v2/encounters.schema.json
+++ b/schemas/ndjson/v2/encounters.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HealthDelta NDJSON Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "record_key",
+    "canonical_person_id",
+    "source",
+    "source_file",
+    "event_time",
+    "run_id"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 2 },
+    "record_key": { "type": "string" },
+    "canonical_person_id": { "type": "string" },
+    "source": { "type": "string" },
+    "source_file": { "type": "string" },
+    "event_time": { "type": "string" },
+    "run_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/ndjson/v2/medications.schema.json
+++ b/schemas/ndjson/v2/medications.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HealthDelta NDJSON Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "record_key",
+    "canonical_person_id",
+    "source",
+    "source_file",
+    "event_time",
+    "run_id"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 2 },
+    "record_key": { "type": "string" },
+    "canonical_person_id": { "type": "string" },
+    "source": { "type": "string" },
+    "source_file": { "type": "string" },
+    "event_time": { "type": "string" },
+    "run_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/ndjson/v2/observations.schema.json
+++ b/schemas/ndjson/v2/observations.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HealthDelta NDJSON Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "record_key",
+    "canonical_person_id",
+    "source",
+    "source_file",
+    "event_time",
+    "run_id"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 2 },
+    "record_key": { "type": "string" },
+    "canonical_person_id": { "type": "string" },
+    "source": { "type": "string" },
+    "source_file": { "type": "string" },
+    "event_time": { "type": "string" },
+    "run_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/ndjson/v2/procedures.schema.json
+++ b/schemas/ndjson/v2/procedures.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HealthDelta NDJSON Record",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "record_key",
+    "canonical_person_id",
+    "source",
+    "source_file",
+    "event_time",
+    "run_id"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 2 },
+    "record_key": { "type": "string" },
+    "canonical_person_id": { "type": "string" },
+    "source": { "type": "string" },
+    "source_file": { "type": "string" },
+    "event_time": { "type": "string" },
+    "run_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/tests/test_ndjson_validate.py
+++ b/tests/test_ndjson_validate.py
@@ -11,6 +11,21 @@ def _write(path: Path, text: str) -> None:
 
 
 class TestNdjsonValidate(unittest.TestCase):
+    def test_schema_files_exist_for_all_streams(self) -> None:
+        root = Path(__file__).resolve().parents[1] / "schemas" / "ndjson" / "v2"
+        expected = {
+            "observations.schema.json",
+            "documents.schema.json",
+            "medications.schema.json",
+            "conditions.schema.json",
+            "encounters.schema.json",
+            "procedures.schema.json",
+            "diagnostic_reports.schema.json",
+        }
+        self.assertTrue(root.exists(), msg=f"missing schema dir: {root}")
+        got = {p.name for p in root.glob("*.schema.json")}
+        self.assertTrue(expected.issubset(got), msg=f"missing schema files: {sorted(expected - got)}")
+
     def test_validate_ok(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -97,6 +112,25 @@ class TestNdjsonValidate(unittest.TestCase):
             )
             self.assertEqual(r.returncode, 1, msg=f"stdout={r.stdout}\nstderr={r.stderr}")
             self.assertIn("missing_trailing_newline", r.stderr)
+
+    def test_validate_fails_on_unknown_schema_version(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            nd = root / "ndjson"
+            nd.mkdir(parents=True, exist_ok=True)
+
+            _write(
+                nd / "observations.ndjson",
+                '{"schema_version":3,"record_key":"k1","canonical_person_id":"p1","source":"healthkit","source_file":"source/export.xml","event_time":"2020-01-01T00:00:00Z","run_id":"r1"}\n',
+            )
+
+            r = subprocess.run(
+                [sys.executable, "-m", "healthdelta", "export", "validate", "--input", str(nd)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(r.returncode, 1, msg=f"stdout={r.stdout}\nstderr={r.stderr}")
+            self.assertIn("schema_version_incompatible", r.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Issue: #82

Adds versioned NDJSON stream schemas and schema-compatibility validation.

## What changed
- Added formal JSON schema files for each NDJSON stream under `schemas/ndjson/v2/*.schema.json`.
- Updated `export validate` to resolve schemas by `(stream, schema_version)` and fail with `schema_version_incompatible` when missing.
- Added tests to verify schema file coverage and invalid schema version detection.

## Validation
- `TZ=UTC python3 -m unittest tests/test_ndjson_validate.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #82
