### PR TITLE
DuckDB/reporting: include new FHIR types

### DIFF
--- a/.ai/prompts/issue_83.md
+++ b/.ai/prompts/issue_83.md
@@ -1,0 +1,17 @@
+---
+Story
+As an operator,
+I want DuckDB tables and reports to cover new FHIR resource types,
+So that hospital records show up in Doctor’s Note and summary artifacts.
+
+Context / Why
+Exported records must surface in reporting outputs to be useful.
+
+Acceptance Criteria
+- DuckDB builds tables for new resource types or extends existing ones.
+- Report outputs include counts/time ranges for each new type.
+- Tests validate report contents.
+
+Out of Scope
+- Visualization UI.
+---

--- a/.ai/sessions/2026-02-01/session_8.md
+++ b/.ai/sessions/2026-02-01/session_8.md
@@ -1,0 +1,14 @@
+# Session 8 — 2026-02-01
+
+Issue: #83
+
+Goal
+- Surface newly exported FHIR types (including DiagnosticReport) in DuckDB/report/note outputs.
+
+Notes
+- Added `diagnostic_reports` table loading in DuckDB builder.
+- Extended reporting and doctor-note summaries to include diagnostic report totals/types.
+- Updated DuckDB/report/note tests to assert diagnostic report coverage.
+
+Local verification
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -71,3 +71,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,80,,20,codex,,"de-id free-text narrative redaction for FHIR resources"
 2026-02-01,81,,20,codex,,"CDA discharge sections and encounter timing coverage"
 2026-02-01,82,,20,codex,,"versioned NDJSON schemas and validator compatibility checks"
+2026-02-01,83,,20,codex,,"duckdb/report/note coverage for diagnostic report stream"

--- a/healthdelta/duckdb_tools.py
+++ b/healthdelta/duckdb_tools.py
@@ -195,6 +195,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
         conditions_path = ndjson_root / "conditions.ndjson"
         encounters_path = ndjson_root / "encounters.ndjson"
         procedures_path = ndjson_root / "procedures.ndjson"
+        diagnostic_reports_path = ndjson_root / "diagnostic_reports.ndjson"
 
         if not observations_path.exists():
             raise FileNotFoundError("Missing required NDJSON stream: observations.ndjson")
@@ -585,6 +586,79 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                             obj.get("status") if isinstance(obj.get("status"), str) else None,
                             obj.get("code") if isinstance(obj.get("code"), str) else None,
                             _stable_json(obj.get("code_coding")),
+                            record_key,
+                        ],
+                    )
+
+                    batch += 1
+                    if batch >= 1000:
+                        task.advance(batch)
+                        batch = 0
+                if batch:
+                    task.advance(batch)
+
+        if diagnostic_reports_path.exists():
+            with progress.phase("duckdb: ensure schema (diagnostic_reports)"):
+                con.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS diagnostic_reports (
+                      schema_version INTEGER,
+                      record_key VARCHAR,
+                      canonical_person_id VARCHAR,
+                      source VARCHAR,
+                      source_file VARCHAR,
+                      event_time TIMESTAMP,
+                      run_id VARCHAR,
+                      event_key VARCHAR,
+                      source_id VARCHAR,
+                      resource_type VARCHAR,
+                      status VARCHAR,
+                      code VARCHAR,
+                      code_coding_json VARCHAR,
+                      result_observation_record_keys_json VARCHAR
+                    );
+                    """
+                )
+                _require_columns(con, "diagnostic_reports", ["record_key"])
+                _create_unique_index_if_possible(
+                    con, name="diagnostic_reports_record_key_uq", table="diagnostic_reports", column="record_key"
+                )
+
+            with progress.phase("duckdb: load diagnostic_reports"):
+                task = progress.task("duckdb: load diagnostic_reports", unit="rows")
+                batch = 0
+                for obj in _iter_ndjson(diagnostic_reports_path):
+                    record_key = obj.get("record_key")
+                    if not isinstance(record_key, str) or not record_key:
+                        record_key = obj.get("event_key")
+                    if not isinstance(record_key, str) or not record_key:
+                        record_key = _sha256_text(_stable_json(obj) or "")
+
+                    event_key = obj.get("event_key")
+                    if not isinstance(event_key, str) or not event_key:
+                        event_key = record_key
+
+                    con.execute(
+                        """
+                        INSERT INTO diagnostic_reports
+                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?
+                        WHERE NOT EXISTS (SELECT 1 FROM diagnostic_reports WHERE record_key=?);
+                        """,
+                        [
+                            obj.get("schema_version") if isinstance(obj.get("schema_version"), int) else None,
+                            record_key,
+                            obj.get("canonical_person_id"),
+                            obj.get("source"),
+                            obj.get("source_file"),
+                            _parse_event_time(obj.get("event_time")),
+                            obj.get("run_id"),
+                            event_key,
+                            obj.get("source_id") if isinstance(obj.get("source_id"), str) else None,
+                            obj.get("resource_type") if isinstance(obj.get("resource_type"), str) else None,
+                            obj.get("status") if isinstance(obj.get("status"), str) else None,
+                            obj.get("code") if isinstance(obj.get("code"), str) else None,
+                            _stable_json(obj.get("code_coding")),
+                            _stable_json(obj.get("result_observation_record_keys")),
                             record_key,
                         ],
                     )

--- a/healthdelta/note.py
+++ b/healthdelta/note.py
@@ -74,7 +74,7 @@ def build_doctor_note(*, db_path: str, out_dir: str, mode: str = "share") -> Non
     try:
         with progress.phase("note: scan tables"):
             present = _tables_present(con)
-            tables = [t for t in ["observations", "documents", "medications", "conditions"] if t in present]
+            tables = [t for t in ["observations", "documents", "medications", "conditions", "encounters", "procedures", "diagnostic_reports"] if t in present]
 
         def union_all(select_expr: str) -> str | None:
             if not tables:
@@ -128,8 +128,9 @@ def build_doctor_note(*, db_path: str, out_dir: str, mode: str = "share") -> Non
         # totals per table (include even if missing)
         with progress.phase("note: compute totals"):
             totals: dict[str, int] = {}
-            task = progress.task("note: compute totals", total=4, unit="tables")
-            for t in ["observations", "documents", "medications", "conditions"]:
+            total_keys = ["observations", "documents", "medications", "conditions", "encounters", "procedures", "diagnostic_reports"]
+            task = progress.task("note: compute totals", total=len(total_keys), unit="tables")
+            for t in total_keys:
                 if t in present:
                     totals[t] = int(_scalar(con, f"SELECT COUNT(*) FROM {t};") or 0)
                 else:
@@ -183,6 +184,9 @@ def build_doctor_note(*, db_path: str, out_dir: str, mode: str = "share") -> Non
         lines.append(f"totals.documents={totals['documents']}")
         lines.append(f"totals.medications={totals['medications']}")
         lines.append(f"totals.conditions={totals['conditions']}")
+        lines.append(f"totals.encounters={totals['encounters']}")
+        lines.append(f"totals.procedures={totals['procedures']}")
+        lines.append(f"totals.diagnostic_reports={totals['diagnostic_reports']}")
         lines.append(f"sources.healthkit={sources['healthkit']}")
         lines.append(f"sources.fhir={sources['fhir']}")
         lines.append(f"sources.cda={sources['cda']}")

--- a/healthdelta/reporting.py
+++ b/healthdelta/reporting.py
@@ -125,6 +125,7 @@ def build_report(*, db_path: str, out_dir: str, mode: str = "local") -> None:
                 t
                 for t in [
                     "conditions",
+                    "diagnostic_reports",
                     "documents",
                     "encounters",
                     "medications",
@@ -335,6 +336,24 @@ def build_report(*, db_path: str, out_dir: str, mode: str = "local") -> None:
                     if isinstance(pid, str) and isinstance(rt, str)
                 ]
             )
+        if "diagnostic_reports" in streams:
+            type_rows.extend(
+                [
+                    (pid, f"diagnostic_reports:{rt}", int(n))
+                    for pid, rt, n in _rows(
+                        con,
+                        """
+                        SELECT canonical_person_id,
+                               COALESCE(resource_type, code, 'unknown') AS record_type,
+                               COUNT(*) AS n
+                        FROM diagnostic_reports
+                        GROUP BY canonical_person_id, record_type
+                        ORDER BY canonical_person_id, n DESC, record_type ASC;
+                        """,
+                    )
+                    if isinstance(pid, str) and isinstance(rt, str)
+                ]
+            )
 
         types_by_person: dict[str, list[tuple[str, int]]] = {p: [] for p in people}
         for pid, type_key, n in type_rows:
@@ -383,6 +402,7 @@ def build_report(*, db_path: str, out_dir: str, mode: str = "local") -> None:
                 "conditions_rows",
                 "encounters_rows",
                 "procedures_rows",
+                "diagnostic_reports_rows",
                 "min_event_time",
                 "max_event_time",
             ]
@@ -398,6 +418,7 @@ def build_report(*, db_path: str, out_dir: str, mode: str = "local") -> None:
                         int(rows_map.get("conditions", 0)),
                         int(rows_map.get("encounters", 0)),
                         int(rows_map.get("procedures", 0)),
+                        int(rows_map.get("diagnostic_reports", 0)),
                         p.get("min_event_time") or "",
                         p.get("max_event_time") or "",
                     ]
@@ -554,7 +575,7 @@ def show_report(*, db_path: str) -> None:
         present = _tables_present(con)
         streams = [
             t
-            for t in ["observations", "documents", "medications", "conditions", "encounters", "procedures"]
+            for t in ["observations", "documents", "medications", "conditions", "encounters", "procedures", "diagnostic_reports"]
             if t in present
         ]
         print("HealthDelta Report (terminal)")

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -71,6 +71,10 @@ class TestDuckdbLoader(unittest.TestCase):
                 '{"schema_version":2,"record_key":"p1","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/procedure.json","event_time":"2020-01-06T09:30:00Z","run_id":"run-1","event_key":"p1","resource_type":"Procedure","source_id":"Procedure/p1","status":"completed"}\n'
             )
             _write_text(ndjson / "procedures.ndjson", procedures)
+            diagnostic_reports = (
+                '{"schema_version":2,"record_key":"dr1","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/diag_report.json","event_time":"2020-01-07T08:00:00Z","run_id":"run-1","event_key":"dr1","resource_type":"DiagnosticReport","source_id":"DiagnosticReport/dr1","status":"final"}\n'
+            )
+            _write_text(ndjson / "diagnostic_reports.ndjson", diagnostic_reports)
 
             db_path = root / "out.duckdb"
 
@@ -171,8 +175,27 @@ class TestDuckdbLoader(unittest.TestCase):
             rows = list(csv.DictReader(q4.stdout.splitlines()))
             self.assertEqual(rows[0]["n"], "1")
 
+            q5 = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "healthdelta",
+                    "duckdb",
+                    "query",
+                    "--db",
+                    str(db_path),
+                    "--sql",
+                    "SELECT COUNT(*) AS n FROM diagnostic_reports ORDER BY n;",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(q5.returncode, 0, msg=f"stdout={q5.stdout}\nstderr={q5.stderr}")
+            rows = list(csv.DictReader(q5.stdout.splitlines()))
+            self.assertEqual(rows[0]["n"], "1")
+
             # Ensure the loader did not introduce PII into query output.
-            combined_out = q1.stdout + q2.stdout + q3.stdout + q4.stdout
+            combined_out = q1.stdout + q2.stdout + q3.stdout + q4.stdout + q5.stdout
             self.assertNotIn(pii_name, combined_out)
             self.assertNotIn(pii_dob, combined_out)
             self.assertNotIn(pii_patient_id, combined_out)

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -124,6 +124,9 @@ class TestDoctorNote(unittest.TestCase):
                 "totals.documents=1\n"
                 "totals.medications=0\n"
                 "totals.conditions=0\n"
+                "totals.encounters=0\n"
+                "totals.procedures=0\n"
+                "totals.diagnostic_reports=0\n"
                 "sources.healthkit=1\n"
                 "sources.fhir=1\n"
                 "sources.cda=1\n"
@@ -153,4 +156,3 @@ class TestDoctorNote(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -77,6 +77,10 @@ class TestReports(unittest.TestCase):
                 ndjson / "procedures.ndjson",
                 '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/procedure.json","event_time":"2020-01-06T09:30:00Z","run_id":"run-1","event_key":"p1","resource_type":"Procedure","source_id":"Procedure/p1","status":"completed"}\n',
             )
+            _write_text(
+                ndjson / "diagnostic_reports.ndjson",
+                '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/diag_report.json","event_time":"2020-01-07T08:00:00Z","run_id":"run-1","event_key":"dr1","resource_type":"DiagnosticReport","source_id":"DiagnosticReport/dr1","status":"final"}\n',
+            )
 
             db_path = root / "out.duckdb"
             build = subprocess.run(
@@ -139,6 +143,7 @@ class TestReports(unittest.TestCase):
             self.assertEqual(summary["tables"]["conditions"]["total_rows"], 2)
             self.assertEqual(summary["tables"]["encounters"]["total_rows"], 1)
             self.assertEqual(summary["tables"]["procedures"]["total_rows"], 1)
+            self.assertEqual(summary["tables"]["diagnostic_reports"]["total_rows"], 1)
             self.assertEqual(summary["reference_integrity"]["unresolved_reference_rows_total"], 0)
 
             self.assertEqual(summary["tables"]["observations"]["min_event_time"], "2020-01-01T01:02:03Z")
@@ -152,6 +157,7 @@ class TestReports(unittest.TestCase):
             self.assertEqual(per_person["person-1"]["rows_by_table"]["conditions"], 2)
             self.assertEqual(per_person["person-1"]["rows_by_table"]["encounters"], 1)
             self.assertEqual(per_person["person-1"]["rows_by_table"]["procedures"], 1)
+            self.assertEqual(per_person["person-1"]["rows_by_table"]["diagnostic_reports"], 1)
             self.assertEqual(per_person["person-1"]["min_event_time"], "2020-01-01T01:02:03Z")
             self.assertEqual(per_person["person-1"]["max_event_time"], "2020-01-08T09:00:00Z")
 
@@ -166,6 +172,7 @@ class TestReports(unittest.TestCase):
                 ("conditions", "fhir"): "2",
                 ("encounters", "fhir"): "1",
                 ("procedures", "fhir"): "1",
+                ("diagnostic_reports", "fhir"): "1",
             }
             got = {(r["stream"], r["source"]): r["rows"] for r in by_source}
             for k, v in expected.items():
@@ -181,6 +188,7 @@ class TestReports(unittest.TestCase):
             self.assertEqual(day_stream_source.get(("2020-01-02", "documents", "fhir")), "1")
             self.assertEqual(day_stream_source.get(("2020-01-05", "encounters", "fhir")), "1")
             self.assertEqual(day_stream_source.get(("2020-01-06", "procedures", "fhir")), "1")
+            self.assertEqual(day_stream_source.get(("2020-01-07", "diagnostic_reports", "fhir")), "1")
 
             combined = "".join(p.read_text(encoding="utf-8") for p in expected_paths)
             self.assertNotIn(pii_name, combined)


### PR DESCRIPTION
Issue: #83

Extends DuckDB/reporting/note outputs to include the diagnostic report stream so newly exported FHIR types surface in analytics artifacts.

## What changed
- Added `diagnostic_reports` table support in DuckDB build with deterministic upsert behavior.
- Extended report generation to include `diagnostic_reports` across table summaries, per-person rows, source coverage, timeline counts, and top record types.
- Extended Doctor's Note totals to include encounters/procedures/diagnostic reports for better hospital record visibility.
- Updated DuckDB/report/note tests to validate diagnostic report coverage.

## Validation
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #83
