### PR TITLE
Provenance: share-safe source_system tagging

### DIFF
--- a/.ai/prompts/issue_84.md
+++ b/.ai/prompts/issue_84.md
@@ -1,0 +1,17 @@
+---
+Story
+As an operator,
+I want source system attribution in a share-safe form,
+So that data provenance is visible without exposing PII.
+
+Context / Why
+Operators need to distinguish records from different hospital systems.
+
+Acceptance Criteria
+- Derive a deterministic, non-PII source_system tag (e.g., hashed identifier.system or meta.source).
+- Tag appears in NDJSON and reports.
+- Tests verify stable tagging and absence of raw identifiers.
+
+Out of Scope
+- Human-readable hospital names.
+---

--- a/.ai/sessions/2026-02-01/session_9.md
+++ b/.ai/sessions/2026-02-01/session_9.md
@@ -1,0 +1,15 @@
+# Session 9 — 2026-02-01
+
+Issue: #84
+
+Goal
+- Add deterministic share-safe `source_system` provenance tags to exports and reporting surfaces.
+
+Notes
+- Added hashed `source_system` tagging in NDJSON export using FHIR `meta.source` or reference identifier systems.
+- Added `source_system` persistence through DuckDB tables and report-level source-system coverage CSV.
+- Extended NDJSON/report tests to validate tagged output and no raw identifier-system leakage.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_ndjson_export.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -72,3 +72,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,81,,20,codex,,"CDA discharge sections and encounter timing coverage"
 2026-02-01,82,,20,codex,,"versioned NDJSON schemas and validator compatibility checks"
 2026-02-01,83,,20,codex,,"duckdb/report/note coverage for diagnostic report stream"
+2026-02-01,84,,25,codex,,"share-safe source_system tagging through export, duckdb, and reports"

--- a/healthdelta/duckdb_tools.py
+++ b/healthdelta/duckdb_tools.py
@@ -92,6 +92,13 @@ def _require_columns(con, table: str, required: list[str]) -> None:
         raise RuntimeError(f"DB schema for table '{table}' is missing columns {missing}; rerun with --replace")
 
 
+def _add_column_if_missing(con, table: str, column: str, col_type: str) -> None:
+    cols = set(_table_columns(con, table))
+    if column in cols:
+        return
+    con.execute(f"ALTER TABLE {table} ADD COLUMN {column} {col_type};")
+
+
 def _create_unique_index_if_possible(con, *, name: str, table: str, column: str) -> None:
     try:
         con.execute(f"CREATE UNIQUE INDEX IF NOT EXISTS {name} ON {table}({column});")
@@ -151,6 +158,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                   record_key VARCHAR,
                   canonical_person_id VARCHAR,
                   source VARCHAR,
+                  source_system VARCHAR,
                   source_file VARCHAR,
                   event_time TIMESTAMP,
                   run_id VARCHAR,
@@ -176,6 +184,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                   record_key VARCHAR,
                   canonical_person_id VARCHAR,
                   source VARCHAR,
+                  source_system VARCHAR,
                   source_file VARCHAR,
                   event_time TIMESTAMP,
                   run_id VARCHAR,
@@ -205,6 +214,8 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
         with progress.phase("duckdb: schema checks"):
             _require_columns(con, "observations", ["record_key"])
             _require_columns(con, "documents", ["record_key"])
+            _add_column_if_missing(con, "observations", "source_system", "VARCHAR")
+            _add_column_if_missing(con, "documents", "source_system", "VARCHAR")
             _create_unique_index_if_possible(
                 con, name="observations_record_key_uq", table="observations", column="record_key"
             )
@@ -240,7 +251,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                 con.execute(
                     """
                     INSERT INTO observations
-                    SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
+                    SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
                     WHERE NOT EXISTS (SELECT 1 FROM observations WHERE record_key=?);
                     """,
                     [
@@ -248,6 +259,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                         record_key,
                         obj.get("canonical_person_id"),
                         obj.get("source"),
+                        obj.get("source_system") if isinstance(obj.get("source_system"), str) else None,
                         obj.get("source_file") or ios_source_file,
                         _parse_event_time(obj.get("event_time") or obj.get("start_time")),
                         obj.get("run_id") or ios_run_id,
@@ -292,7 +304,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     con.execute(
                         """
                         INSERT INTO documents
-                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?
+                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?
                         WHERE NOT EXISTS (SELECT 1 FROM documents WHERE record_key=?);
                         """,
                         [
@@ -300,6 +312,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                             record_key,
                             obj.get("canonical_person_id"),
                             obj.get("source"),
+                            obj.get("source_system") if isinstance(obj.get("source_system"), str) else None,
                             obj.get("source_file") or ("ndjson/documents.ndjson" if ios_mode else None),
                             _parse_event_time(obj.get("event_time")),
                             obj.get("run_id") or ios_run_id,
@@ -328,6 +341,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                       record_key VARCHAR,
                       canonical_person_id VARCHAR,
                       source VARCHAR,
+                      source_system VARCHAR,
                       source_file VARCHAR,
                       event_time TIMESTAMP,
                       run_id VARCHAR,
@@ -339,6 +353,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     """
                 )
                 _require_columns(con, "medications", ["record_key"])
+                _add_column_if_missing(con, "medications", "source_system", "VARCHAR")
                 _create_unique_index_if_possible(
                     con, name="medications_record_key_uq", table="medications", column="record_key"
                 )
@@ -360,7 +375,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     con.execute(
                         """
                         INSERT INTO medications
-                        SELECT ?,?,?,?,?,?,?,?,?,?,?
+                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?
                         WHERE NOT EXISTS (SELECT 1 FROM medications WHERE record_key=?);
                         """,
                         [
@@ -368,6 +383,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                             record_key,
                             obj.get("canonical_person_id"),
                             obj.get("source"),
+                            obj.get("source_system") if isinstance(obj.get("source_system"), str) else None,
                             obj.get("source_file"),
                             _parse_event_time(obj.get("event_time")),
                             obj.get("run_id"),
@@ -395,6 +411,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                       record_key VARCHAR,
                       canonical_person_id VARCHAR,
                       source VARCHAR,
+                      source_system VARCHAR,
                       source_file VARCHAR,
                       event_time TIMESTAMP,
                       run_id VARCHAR,
@@ -407,6 +424,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     """
                 )
                 _require_columns(con, "conditions", ["record_key"])
+                _add_column_if_missing(con, "conditions", "source_system", "VARCHAR")
                 _create_unique_index_if_possible(
                     con, name="conditions_record_key_uq", table="conditions", column="record_key"
                 )
@@ -428,7 +446,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     con.execute(
                         """
                         INSERT INTO conditions
-                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?
+                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?
                         WHERE NOT EXISTS (SELECT 1 FROM conditions WHERE record_key=?);
                         """,
                         [
@@ -436,6 +454,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                             record_key,
                             obj.get("canonical_person_id"),
                             obj.get("source"),
+                            obj.get("source_system") if isinstance(obj.get("source_system"), str) else None,
                             obj.get("source_file"),
                             _parse_event_time(obj.get("event_time")),
                             obj.get("run_id"),
@@ -464,6 +483,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                       record_key VARCHAR,
                       canonical_person_id VARCHAR,
                       source VARCHAR,
+                      source_system VARCHAR,
                       source_file VARCHAR,
                       event_time TIMESTAMP,
                       run_id VARCHAR,
@@ -477,6 +497,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     """
                 )
                 _require_columns(con, "encounters", ["record_key"])
+                _add_column_if_missing(con, "encounters", "source_system", "VARCHAR")
                 _create_unique_index_if_possible(
                     con, name="encounters_record_key_uq", table="encounters", column="record_key"
                 )
@@ -498,7 +519,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     con.execute(
                         """
                         INSERT INTO encounters
-                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?
+                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?
                         WHERE NOT EXISTS (SELECT 1 FROM encounters WHERE record_key=?);
                         """,
                         [
@@ -506,6 +527,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                             record_key,
                             obj.get("canonical_person_id"),
                             obj.get("source"),
+                            obj.get("source_system") if isinstance(obj.get("source_system"), str) else None,
                             obj.get("source_file"),
                             _parse_event_time(obj.get("event_time")),
                             obj.get("run_id"),
@@ -535,6 +557,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                       record_key VARCHAR,
                       canonical_person_id VARCHAR,
                       source VARCHAR,
+                      source_system VARCHAR,
                       source_file VARCHAR,
                       event_time TIMESTAMP,
                       run_id VARCHAR,
@@ -548,6 +571,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     """
                 )
                 _require_columns(con, "procedures", ["record_key"])
+                _add_column_if_missing(con, "procedures", "source_system", "VARCHAR")
                 _create_unique_index_if_possible(
                     con, name="procedures_record_key_uq", table="procedures", column="record_key"
                 )
@@ -569,7 +593,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     con.execute(
                         """
                         INSERT INTO procedures
-                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?
+                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?
                         WHERE NOT EXISTS (SELECT 1 FROM procedures WHERE record_key=?);
                         """,
                         [
@@ -577,6 +601,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                             record_key,
                             obj.get("canonical_person_id"),
                             obj.get("source"),
+                            obj.get("source_system") if isinstance(obj.get("source_system"), str) else None,
                             obj.get("source_file"),
                             _parse_event_time(obj.get("event_time")),
                             obj.get("run_id"),
@@ -606,6 +631,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                       record_key VARCHAR,
                       canonical_person_id VARCHAR,
                       source VARCHAR,
+                      source_system VARCHAR,
                       source_file VARCHAR,
                       event_time TIMESTAMP,
                       run_id VARCHAR,
@@ -620,6 +646,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     """
                 )
                 _require_columns(con, "diagnostic_reports", ["record_key"])
+                _add_column_if_missing(con, "diagnostic_reports", "source_system", "VARCHAR")
                 _create_unique_index_if_possible(
                     con, name="diagnostic_reports_record_key_uq", table="diagnostic_reports", column="record_key"
                 )
@@ -641,7 +668,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                     con.execute(
                         """
                         INSERT INTO diagnostic_reports
-                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?
+                        SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
                         WHERE NOT EXISTS (SELECT 1 FROM diagnostic_reports WHERE record_key=?);
                         """,
                         [
@@ -649,6 +676,7 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                             record_key,
                             obj.get("canonical_person_id"),
                             obj.get("source"),
+                            obj.get("source_system") if isinstance(obj.get("source_system"), str) else None,
                             obj.get("source_file"),
                             _parse_event_time(obj.get("event_time")),
                             obj.get("run_id"),

--- a/healthdelta/ndjson_export.py
+++ b/healthdelta/ndjson_export.py
@@ -20,6 +20,10 @@ def _sha256_bytes(b: bytes) -> str:
     return hashlib.sha256(b).hexdigest()
 
 
+def _source_system_tag(raw: str) -> str:
+    return "ss_" + _sha256_bytes(raw.encode("utf-8"))[:12]
+
+
 def _write_ndjson(path: Path, rows: list[dict]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=str(path.parent)) as tf:
@@ -278,6 +282,19 @@ def _resolve_fhir_person_id(ctx: ExportContext, resource: dict) -> str:
     return _canonical_person_id(ctx)
 
 
+def _derive_fhir_source_system(resource: dict) -> str:
+    meta = resource.get("meta")
+    if isinstance(meta, dict):
+        src = meta.get("source")
+        if isinstance(src, str) and src.strip():
+            return _source_system_tag(f"meta.source:{src.strip()}")
+    pairs = _extract_fhir_reference_identifier_pairs(resource)
+    for system, _ in pairs:
+        if isinstance(system, str) and system.strip():
+            return _source_system_tag(f"identifier.system:{system.strip()}")
+    return _source_system_tag("fhir:default")
+
+
 def _extract_fhir_reference_id(ref: str, resource_type: str) -> str | None:
     if not isinstance(ref, str) or not ref.strip():
         return None
@@ -331,6 +348,7 @@ def _export_healthkit_observations(ctx: ExportContext) -> list[dict]:
             "schema_version": 2,
             "canonical_person_id": _canonical_person_id(ctx),
             "source": "healthkit",
+            "source_system": _source_system_tag("healthkit:export.xml"),
             "source_file": _safe_relpath(ctx.export_xml_rel),
             "event_time": event_time,
             "run_id": ctx.run_id,
@@ -498,6 +516,7 @@ def _export_fhir_streams(
             "schema_version": 2,
             "canonical_person_id": person,
             "source": "fhir",
+            "source_system": _derive_fhir_source_system(res),
             "source_file": _safe_relpath(rel),
             "event_time": event_time,
             "run_id": ctx.run_id,
@@ -769,6 +788,7 @@ def _export_cda_streams(ctx: ExportContext) -> tuple[list[dict], list[dict]]:
                 "schema_version": 2,
                 "canonical_person_id": _canonical_person_id(ctx),
                 "source": "cda",
+                "source_system": _source_system_tag("cda:export_cda.xml"),
                 "source_file": _safe_relpath(ctx.export_cda_rel),
                 "event_time": section_time,
                 "run_id": ctx.run_id,
@@ -792,6 +812,7 @@ def _export_cda_streams(ctx: ExportContext) -> tuple[list[dict], list[dict]]:
                 "schema_version": 2,
                 "canonical_person_id": _canonical_person_id(ctx),
                 "source": "cda",
+                "source_system": _source_system_tag("cda:export_cda.xml"),
                 "source_file": _safe_relpath(ctx.export_cda_rel),
                 "event_time": effective_time,
                 "run_id": ctx.run_id,
@@ -823,6 +844,7 @@ def _export_cda_streams(ctx: ExportContext) -> tuple[list[dict], list[dict]]:
                 "schema_version": 2,
                 "canonical_person_id": _canonical_person_id(ctx),
                 "source": "cda",
+                "source_system": _source_system_tag("cda:export_cda.xml"),
                 "source_file": _safe_relpath(ctx.export_cda_rel),
                 "event_time": event_time,
                 "run_id": ctx.run_id,

--- a/healthdelta/reporting.py
+++ b/healthdelta/reporting.py
@@ -137,6 +137,7 @@ def build_report(*, db_path: str, out_dir: str, mode: str = "local") -> None:
 
         tables_summary: dict[str, dict[str, object]] = {}
         coverage_by_source_rows: list[tuple[str, str, int]] = []
+        coverage_by_source_system_rows: list[tuple[str, str, int]] = []
 
         source_bucket = "CASE WHEN source_file LIKE 'ndjson/%' THEN 'ios' ELSE source END"
 
@@ -155,12 +156,29 @@ def build_report(*, db_path: str, out_dir: str, mode: str = "local") -> None:
                         by_source_map[source] = int(n)
                         coverage_by_source_rows.append((table, source, int(n)))
 
+                by_source_system = _rows(
+                    con,
+                    f"""
+                    SELECT COALESCE(source_system, '') AS source_system, COUNT(*) AS n
+                    FROM {table}
+                    GROUP BY 1
+                    ORDER BY 1;
+                    """,
+                )
+                by_source_system_map: dict[str, int] = {}
+                for source_system, n in by_source_system:
+                    if isinstance(source_system, str):
+                        key = source_system or "unknown"
+                        by_source_system_map[key] = int(n)
+                        coverage_by_source_system_rows.append((table, key, int(n)))
+
                 tables_summary[table] = {
                     "total_rows": total_rows,
                     "distinct_canonical_person_id": distinct_people,
                     "min_event_time": _fmt_ts(min_et),
                     "max_event_time": _fmt_ts(max_et),
                     "rows_by_source": {k: by_source_map[k] for k in sorted(by_source_map)},
+                    "rows_by_source_system": {k: by_source_system_map[k] for k in sorted(by_source_system_map)},
                 }
                 task.advance(1)
 
@@ -391,7 +409,7 @@ def build_report(*, db_path: str, out_dir: str, mode: str = "local") -> None:
                 task_people.advance(batch)
 
         with progress.phase("report: write artifacts"):
-            task_write = progress.task("report: write artifacts", total=5, unit="files")
+            task_write = progress.task("report: write artifacts", total=6, unit="files")
 
             # CSV: coverage_by_person.csv
             header = [
@@ -433,6 +451,15 @@ def build_report(*, db_path: str, out_dir: str, mode: str = "local") -> None:
                 out / "coverage_by_source.csv",
                 header=["stream", "source", "rows"],
                 rows=[[stream, source, n] for stream, source, n in coverage_by_source_rows],
+            )
+            task_write.advance(1)
+
+            # CSV: coverage_by_source_system.csv
+            coverage_by_source_system_rows.sort(key=lambda r: (r[0], r[1]))
+            _write_csv(
+                out / "coverage_by_source_system.csv",
+                header=["stream", "source_system", "rows"],
+                rows=[[stream, source_system, n] for stream, source_system, n in coverage_by_source_system_rows],
             )
             task_write.advance(1)
 

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -36,43 +36,43 @@ class TestDuckdbLoader(unittest.TestCase):
             observations = "\n".join(
                 [
                     # healthkit observation row (plus extra fields that should be ignored)
-                    '{"schema_version":2,"record_key":"k1","canonical_person_id":"person-1","source":"healthkit","source_file":"source/export.xml","event_time":"2020-01-01T05:00:00Z","run_id":"run-1","event_key":"k1","hk_type":"HKQuantityTypeIdentifierHeartRate","value":"72","unit":"count/min","pii_name":"%s","dob":"%s"}'
+                    '{"schema_version":2,"record_key":"k1","canonical_person_id":"person-1","source":"healthkit","source_system":"ss_healthkit","source_file":"source/export.xml","event_time":"2020-01-01T05:00:00Z","run_id":"run-1","event_key":"k1","hk_type":"HKQuantityTypeIdentifierHeartRate","value":"72","unit":"count/min","pii_name":"%s","dob":"%s"}'
                     % (pii_name, pii_dob),
                     # fhir observation row
-                    '{"schema_version":2,"record_key":"k2","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/obs.json","event_time":"2020-01-01T01:02:03Z","run_id":"run-1","event_key":"k2","resource_type":"Observation","source_id":"Observation/o1","value":72,"unit":"count/min","pii_id":"%s"}'
+                    '{"schema_version":2,"record_key":"k2","canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/obs.json","event_time":"2020-01-01T01:02:03Z","run_id":"run-1","event_key":"k2","resource_type":"Observation","source_id":"Observation/o1","value":72,"unit":"count/min","pii_id":"%s"}'
                     % pii_patient_id,
                     # cda observation row
-                    '{"schema_version":2,"record_key":"k3","canonical_person_id":"person-1","source":"cda","source_file":"source/unpacked/export_cda.xml","event_time":"2020-01-01T11:22:33Z","run_id":"run-1","event_key":"k3","code":"8867-4","value":"72","unit":"/min"}',
+                    '{"schema_version":2,"record_key":"k3","canonical_person_id":"person-1","source":"cda","source_system":"ss_cda","source_file":"source/unpacked/export_cda.xml","event_time":"2020-01-01T11:22:33Z","run_id":"run-1","event_key":"k3","code":"8867-4","value":"72","unit":"/min"}',
                 ]
             )
             _write_text(ndjson / "observations.ndjson", observations + "\n")
 
             documents = (
-                '{"schema_version":2,"record_key":"d1","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/doc.json","event_time":"2020-01-02T03:04:05Z","run_id":"run-1","event_key":"d1","resource_type":"DocumentReference","source_id":"DocumentReference/d1","status":"current"}\n'
+                '{"schema_version":2,"record_key":"d1","canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/doc.json","event_time":"2020-01-02T03:04:05Z","run_id":"run-1","event_key":"d1","resource_type":"DocumentReference","source_id":"DocumentReference/d1","status":"current"}\n'
             )
             _write_text(ndjson / "documents.ndjson", documents)
 
             medications = (
-                '{"schema_version":2,"record_key":"m1","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/med.json","event_time":"2020-01-03T00:00:00Z","run_id":"run-1","event_key":"m1","resource_type":"MedicationRequest","source_id":"MedicationRequest/m1","status":"active"}\n'
+                '{"schema_version":2,"record_key":"m1","canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/med.json","event_time":"2020-01-03T00:00:00Z","run_id":"run-1","event_key":"m1","resource_type":"MedicationRequest","source_id":"MedicationRequest/m1","status":"active"}\n'
             )
             _write_text(ndjson / "medications.ndjson", medications)
 
             conditions = (
-                '{"schema_version":2,"record_key":"c1","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/cond.json","event_time":"2020-01-04T00:00:00Z","run_id":"run-1","event_key":"c1","resource_type":"Condition","source_id":"Condition/c1"}\n'
+                '{"schema_version":2,"record_key":"c1","canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/cond.json","event_time":"2020-01-04T00:00:00Z","run_id":"run-1","event_key":"c1","resource_type":"Condition","source_id":"Condition/c1"}\n'
             )
             _write_text(ndjson / "conditions.ndjson", conditions)
 
             encounters = (
-                '{"schema_version":2,"record_key":"e1","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/encounter.json","event_time":"2020-01-05T10:00:00Z","run_id":"run-1","event_key":"e1","resource_type":"Encounter","source_id":"Encounter/e1","status":"finished"}\n'
+                '{"schema_version":2,"record_key":"e1","canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/encounter.json","event_time":"2020-01-05T10:00:00Z","run_id":"run-1","event_key":"e1","resource_type":"Encounter","source_id":"Encounter/e1","status":"finished"}\n'
             )
             _write_text(ndjson / "encounters.ndjson", encounters)
 
             procedures = (
-                '{"schema_version":2,"record_key":"p1","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/procedure.json","event_time":"2020-01-06T09:30:00Z","run_id":"run-1","event_key":"p1","resource_type":"Procedure","source_id":"Procedure/p1","status":"completed"}\n'
+                '{"schema_version":2,"record_key":"p1","canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/procedure.json","event_time":"2020-01-06T09:30:00Z","run_id":"run-1","event_key":"p1","resource_type":"Procedure","source_id":"Procedure/p1","status":"completed"}\n'
             )
             _write_text(ndjson / "procedures.ndjson", procedures)
             diagnostic_reports = (
-                '{"schema_version":2,"record_key":"dr1","canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/diag_report.json","event_time":"2020-01-07T08:00:00Z","run_id":"run-1","event_key":"dr1","resource_type":"DiagnosticReport","source_id":"DiagnosticReport/dr1","status":"final"}\n'
+                '{"schema_version":2,"record_key":"dr1","canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/diag_report.json","event_time":"2020-01-07T08:00:00Z","run_id":"run-1","event_key":"dr1","resource_type":"DiagnosticReport","source_id":"DiagnosticReport/dr1","status":"final"}\n'
             )
             _write_text(ndjson / "diagnostic_reports.ndjson", diagnostic_reports)
 

--- a/tests/test_ndjson_export.py
+++ b/tests/test_ndjson_export.py
@@ -380,6 +380,11 @@ class TestNdjsonExport(unittest.TestCase):
             self.assertEqual(by_source_id["Observation/o-fallback"]["canonical_person_id"], "person-a")
             self.assertEqual(by_source_id["Observation/o-ambiguous"]["canonical_person_id"], "unresolved")
             self.assertEqual(by_source_id["Immunization/i-subject"]["canonical_person_id"], "person-a")
+            for row in by_source_id.values():
+                self.assertIsInstance(row.get("source_system"), str)
+                self.assertTrue(row.get("source_system", "").startswith("ss_"))
+                self.assertEqual(len(row.get("source_system", "")), 15)
+                self.assertNotIn("urn:mrn", row.get("source_system", ""))
 
     def test_export_ndjson_local_and_share_are_deterministic_and_pii_free(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -524,12 +529,14 @@ class TestNdjsonExport(unittest.TestCase):
                 self.assertIn("schema_version", row)
                 self.assertIn("canonical_person_id", row)
                 self.assertIn("source", row)
+                self.assertIn("source_system", row)
                 self.assertIn("source_file", row)
                 self.assertIn("event_time", row)
                 self.assertIn("run_id", row)
                 self.assertIn("record_key", row)
                 self.assertIsInstance(row["canonical_person_id"], str)
                 self.assertIn(row["source"], ["healthkit", "fhir", "cda"])
+                self.assertTrue(row["source_system"].startswith("ss_"))
                 self.assertIsInstance(row["source_file"], str)
                 self.assertIsInstance(row["schema_version"], int)
                 self.assertIsInstance(row["record_key"], str)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -41,45 +41,45 @@ class TestReports(unittest.TestCase):
                 ndjson / "observations.ndjson",
                 "\n".join(
                     [
-                        '{"canonical_person_id":"person-1","source":"healthkit","source_file":"source/export.xml","event_time":"2020-01-01T05:00:00Z","run_id":"run-1","event_key":"k1","hk_type":"HKQuantityTypeIdentifierHeartRate","value":"72","unit":"count/min","pii_name":"%s","dob":"%s"}'
+                        '{"canonical_person_id":"person-1","source":"healthkit","source_system":"ss_healthkit","source_file":"source/export.xml","event_time":"2020-01-01T05:00:00Z","run_id":"run-1","event_key":"k1","hk_type":"HKQuantityTypeIdentifierHeartRate","value":"72","unit":"count/min","pii_name":"%s","dob":"%s"}'
                         % (pii_name, pii_dob),
-                        '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/obs.json","event_time":"2020-01-01T01:02:03Z","run_id":"run-1","event_key":"k2","resource_type":"Observation","source_id":"Observation/o1","value":72,"unit":"count/min","pii_id":"%s"}'
+                        '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/obs.json","event_time":"2020-01-01T01:02:03Z","run_id":"run-1","event_key":"k2","resource_type":"Observation","source_id":"Observation/o1","value":72,"unit":"count/min","pii_id":"%s"}'
                         % pii_patient_id,
-                        '{"canonical_person_id":"person-1","source":"cda","source_file":"source/unpacked/export_cda.xml","event_time":"2020-01-01T11:22:33Z","run_id":"run-1","event_key":"k3","code":"8867-4","value":"72","unit":"/min"}',
-                        '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/immunization.json","event_time":"2020-01-08T09:00:00Z","run_id":"run-1","event_key":"i1","resource_type":"Immunization","source_id":"Immunization/i1","status":"completed"}',
+                        '{"canonical_person_id":"person-1","source":"cda","source_system":"ss_cda","source_file":"source/unpacked/export_cda.xml","event_time":"2020-01-01T11:22:33Z","run_id":"run-1","event_key":"k3","code":"8867-4","value":"72","unit":"/min"}',
+                        '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/immunization.json","event_time":"2020-01-08T09:00:00Z","run_id":"run-1","event_key":"i1","resource_type":"Immunization","source_id":"Immunization/i1","status":"completed"}',
                     ]
                 )
                 + "\n",
             )
             _write_text(
                 ndjson / "documents.ndjson",
-                '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/doc.json","event_time":"2020-01-02T03:04:05Z","run_id":"run-1","event_key":"d1","resource_type":"DocumentReference","source_id":"DocumentReference/d1","status":"current"}\n',
+                '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/doc.json","event_time":"2020-01-02T03:04:05Z","run_id":"run-1","event_key":"d1","resource_type":"DocumentReference","source_id":"DocumentReference/d1","status":"current"}\n',
             )
             _write_text(
                 ndjson / "medications.ndjson",
-                '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/med.json","event_time":"2020-01-03T00:00:00Z","run_id":"run-1","event_key":"m1","resource_type":"MedicationRequest","source_id":"MedicationRequest/m1","status":"active"}\n',
+                '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/med.json","event_time":"2020-01-03T00:00:00Z","run_id":"run-1","event_key":"m1","resource_type":"MedicationRequest","source_id":"MedicationRequest/m1","status":"active"}\n',
             )
             _write_text(
                 ndjson / "conditions.ndjson",
                 "\n".join(
                     [
-                        '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/cond.json","event_time":"2020-01-04T00:00:00Z","run_id":"run-1","event_key":"c1","resource_type":"Condition","source_id":"Condition/c1","code":"I10"}',
-                        '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/allergy.json","event_time":"2020-01-04T07:00:00Z","run_id":"run-1","event_key":"a1","resource_type":"AllergyIntolerance","source_id":"AllergyIntolerance/a1"}',
+                        '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/cond.json","event_time":"2020-01-04T00:00:00Z","run_id":"run-1","event_key":"c1","resource_type":"Condition","source_id":"Condition/c1","code":"I10"}',
+                        '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/allergy.json","event_time":"2020-01-04T07:00:00Z","run_id":"run-1","event_key":"a1","resource_type":"AllergyIntolerance","source_id":"AllergyIntolerance/a1"}',
                     ]
                 )
                 + "\n",
             )
             _write_text(
                 ndjson / "encounters.ndjson",
-                '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/encounter.json","event_time":"2020-01-05T10:00:00Z","run_id":"run-1","event_key":"e1","resource_type":"Encounter","source_id":"Encounter/e1","status":"finished"}\n',
+                '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/encounter.json","event_time":"2020-01-05T10:00:00Z","run_id":"run-1","event_key":"e1","resource_type":"Encounter","source_id":"Encounter/e1","status":"finished"}\n',
             )
             _write_text(
                 ndjson / "procedures.ndjson",
-                '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/procedure.json","event_time":"2020-01-06T09:30:00Z","run_id":"run-1","event_key":"p1","resource_type":"Procedure","source_id":"Procedure/p1","status":"completed"}\n',
+                '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/procedure.json","event_time":"2020-01-06T09:30:00Z","run_id":"run-1","event_key":"p1","resource_type":"Procedure","source_id":"Procedure/p1","status":"completed"}\n',
             )
             _write_text(
                 ndjson / "diagnostic_reports.ndjson",
-                '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/diag_report.json","event_time":"2020-01-07T08:00:00Z","run_id":"run-1","event_key":"dr1","resource_type":"DiagnosticReport","source_id":"DiagnosticReport/dr1","status":"final"}\n',
+                '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/diag_report.json","event_time":"2020-01-07T08:00:00Z","run_id":"run-1","event_key":"dr1","resource_type":"DiagnosticReport","source_id":"DiagnosticReport/dr1","status":"final"}\n',
             )
 
             db_path = root / "out.duckdb"
@@ -126,6 +126,7 @@ class TestReports(unittest.TestCase):
                 out_dir / "summary.md",
                 out_dir / "coverage_by_person.csv",
                 out_dir / "coverage_by_source.csv",
+                out_dir / "coverage_by_source_system.csv",
                 out_dir / "timeline_daily_counts.csv",
                 out_dir / "reference_integrity_unresolved.csv",
             ]
@@ -178,6 +179,12 @@ class TestReports(unittest.TestCase):
             for k, v in expected.items():
                 self.assertEqual(got.get(k), v)
 
+            by_source_system = _read_csv(out_dir / "coverage_by_source_system.csv")
+            ss = {(r["stream"], r["source_system"]): r["rows"] for r in by_source_system}
+            self.assertEqual(ss.get(("observations", "ss_fhir")), "2")
+            self.assertEqual(ss.get(("observations", "ss_healthkit")), "1")
+            self.assertEqual(ss.get(("observations", "ss_cda")), "1")
+
             timeline = _read_csv(out_dir / "timeline_daily_counts.csv")
             # day is YYYY-MM-DD
             day_stream_source = {(r["day"], r["stream"], r["source"]): r["rows"] for r in timeline}
@@ -228,20 +235,20 @@ class TestReports(unittest.TestCase):
                 ndjson / "encounters.ndjson",
                 "\n".join(
                     [
-                        '{"canonical_person_id":"person-1","source":"fhir","source_file":"source/clinical/encounter_ok.json","event_time":"2020-01-05T10:00:00Z","run_id":"run-1","event_key":"e-ok","resource_type":"Encounter","source_id":"Encounter/e-ok","status":"finished"}',
-                        '{"canonical_person_id":"unresolved","source":"fhir","source_file":"source/clinical/encounter_bad_1.json","event_time":"2020-01-05T11:00:00Z","run_id":"run-1","event_key":"e-bad-1","resource_type":"Encounter","source_id":"Encounter/e-bad-1","status":"finished"}',
-                        '{"canonical_person_id":"unresolved","source":"fhir","source_file":"source/clinical/encounter_bad_2.json","event_time":"2020-01-05T12:00:00Z","run_id":"run-1","event_key":"e-bad-2","resource_type":"Encounter","source_id":"Encounter/e-bad-2","status":"finished"}',
+                        '{"canonical_person_id":"person-1","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/encounter_ok.json","event_time":"2020-01-05T10:00:00Z","run_id":"run-1","event_key":"e-ok","resource_type":"Encounter","source_id":"Encounter/e-ok","status":"finished"}',
+                        '{"canonical_person_id":"unresolved","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/encounter_bad_1.json","event_time":"2020-01-05T11:00:00Z","run_id":"run-1","event_key":"e-bad-1","resource_type":"Encounter","source_id":"Encounter/e-bad-1","status":"finished"}',
+                        '{"canonical_person_id":"unresolved","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/encounter_bad_2.json","event_time":"2020-01-05T12:00:00Z","run_id":"run-1","event_key":"e-bad-2","resource_type":"Encounter","source_id":"Encounter/e-bad-2","status":"finished"}',
                     ]
                 )
                 + "\n",
             )
             _write_text(
                 ndjson / "procedures.ndjson",
-                '{"canonical_person_id":"unresolved","source":"fhir","source_file":"source/clinical/procedure_bad.json","event_time":"2020-01-06T09:30:00Z","run_id":"run-1","event_key":"p-bad-1","resource_type":"Procedure","source_id":"Procedure/p-bad-1","status":"completed"}\n',
+                '{"canonical_person_id":"unresolved","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/procedure_bad.json","event_time":"2020-01-06T09:30:00Z","run_id":"run-1","event_key":"p-bad-1","resource_type":"Procedure","source_id":"Procedure/p-bad-1","status":"completed"}\n',
             )
             _write_text(
                 ndjson / "observations.ndjson",
-                '{"canonical_person_id":"unresolved","source":"fhir","source_file":"source/clinical/immunization_bad.json","event_time":"2020-01-08T09:00:00Z","run_id":"run-1","event_key":"i-bad-1","resource_type":"Immunization","source_id":"Immunization/i-bad-1","status":"completed"}\n',
+                '{"canonical_person_id":"unresolved","source":"fhir","source_system":"ss_fhir","source_file":"source/clinical/immunization_bad.json","event_time":"2020-01-08T09:00:00Z","run_id":"run-1","event_key":"i-bad-1","resource_type":"Immunization","source_id":"Immunization/i-bad-1","status":"completed"}\n',
             )
             _write_text(ndjson / "documents.ndjson", "\n")
             _write_text(ndjson / "medications.ndjson", "\n")


### PR DESCRIPTION
Issue: #84

Implements share-safe deterministic `source_system` provenance tagging.

## What changed
- NDJSON export now emits `source_system` tags using deterministic SHA-based hashes from:
  - FHIR `meta.source` or reference identifier systems
  - fixed source channels for HealthKit/CDA
- DuckDB loader now persists `source_system` across all stream tables.
- Reporting now includes `rows_by_source_system` and a new `coverage_by_source_system.csv` artifact.
- Extended tests to assert:
  - source-system tags are present and stable-format (`ss_...`)
  - raw identifier-system values are not leaked in tags
  - report source-system coverage output exists and includes expected rows.

## Validation
- `TZ=UTC python3 -m unittest tests/test_ndjson_export.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #84
