### PR TITLE
Share bundle: hospital record evidence pack

### DIFF
--- a/.ai/prompts/issue_85.md
+++ b/.ai/prompts/issue_85.md
@@ -1,0 +1,17 @@
+---
+Story
+As an operator,
+I want a single share-safe artifact bundle that proves hospital record ingestion,
+So that I can share evidence without exposing PII.
+
+Context / Why
+The mission requires shareable, auditable outputs.
+
+Acceptance Criteria
+- Bundle includes NDJSON, DuckDB, reports, Doctor’s Note, and validation logs.
+- Share-verify passes and records a deterministic manifest.
+- Tests assert required files and hashes.
+
+Out of Scope
+- UI distribution.
+---

--- a/.ai/sessions/2026-02-01/session_10.md
+++ b/.ai/sessions/2026-02-01/session_10.md
@@ -1,0 +1,15 @@
+# Session 10 — 2026-02-01
+
+Issue: #85
+
+Goal
+- Strengthen share bundle evidence packaging with deterministic validation-log artifacts.
+
+Notes
+- Added registry-level `validation_log.txt` into bundle contents + manifest.
+- Extended verifier to require/validate the new log artifact.
+- Extended bundle test assertions to verify required evidence paths and manifest sha256 entries.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_share_bundle.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -73,3 +73,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,82,,20,codex,,"versioned NDJSON schemas and validator compatibility checks"
 2026-02-01,83,,20,codex,,"duckdb/report/note coverage for diagnostic report stream"
 2026-02-01,84,,25,codex,,"share-safe source_system tagging through export, duckdb, and reports"
+2026-02-01,85,,20,codex,,"share bundle evidence pack with validation log + manifest checks"

--- a/healthdelta/share_bundle.py
+++ b/healthdelta/share_bundle.py
@@ -14,10 +14,11 @@ from healthdelta.state import load_registry
 from healthdelta.progress import progress
 
 
-_ALLOWLIST_DIRS: tuple[str, ...] = ("deid", "ndjson", "duckdb", "reports", "note")
+_ALLOWLIST_DIRS: tuple[str, ...] = ("deid", "ndjson", "duckdb", "reports", "note", "validation")
 _REGISTRY_DIR = "registry"
 _RUN_ENTRY_JSON = "run_entry.json"
 _BUNDLE_MANIFEST_CSV = "bundle_manifest.csv"
+_VALIDATION_LOG_TXT = "validation_log.txt"
 _MANIFEST_HEADER = ["path", "size", "sha256"]
 
 
@@ -122,6 +123,27 @@ def _safe_run_registry_snippet(*, base_out: Path, run_id: str, present_dirs: lis
     }
 
 
+def _validation_log_bytes(*, run_id: str, include_dirs: list[str], file_members: list[tuple[str, Path]]) -> bytes:
+    file_arcs = {arc for arc, _ in file_members}
+    has_duckdb_file = any(arc.startswith(f"{run_id}/duckdb/") and arc.endswith(".duckdb") for arc in file_arcs)
+    checks = {
+        "ndjson_observations": f"{run_id}/ndjson/observations.ndjson" in file_arcs,
+        "reports_summary": f"{run_id}/reports/summary.json" in file_arcs,
+        "note_doctor_note": f"{run_id}/note/doctor_note.txt" in file_arcs,
+        "duckdb_file": has_duckdb_file,
+        "validation_dir_present": "validation" in include_dirs,
+    }
+
+    lines = [
+        "HealthDelta Bundle Validation Log",
+        f"run_id={run_id}",
+        f"included_dirs={','.join(include_dirs)}",
+    ]
+    for key in sorted(checks):
+        lines.append(f"check.{key}={'pass' if checks[key] else 'missing'}")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
 def build_share_bundle(*, run_dir: str, out_path: str) -> None:
     run_root = Path(run_dir)
     if not run_root.is_dir():
@@ -164,14 +186,19 @@ def build_share_bundle(*, run_dir: str, out_path: str) -> None:
     with progress.phase("bundle: build manifest"):
         snippet = _safe_run_registry_snippet(base_out=base_out, run_id=run_id, present_dirs=include_dirs)
         snippet_arc = f"{run_id}/{_REGISTRY_DIR}/{_RUN_ENTRY_JSON}"
+        validation_arc = f"{run_id}/{_REGISTRY_DIR}/{_VALIDATION_LOG_TXT}"
         dir_names.add(f"{run_id}/{_REGISTRY_DIR}/")
+        validation_bytes = _validation_log_bytes(run_id=run_id, include_dirs=include_dirs, file_members=file_members)
 
         # Manifest covers all regular files except the manifest itself.
         manifest_arc = f"{run_id}/{_REGISTRY_DIR}/{_BUNDLE_MANIFEST_CSV}"
         snippet_bytes = _stable_json_bytes(snippet)
-        manifest_entries: list[tuple[str, int, str]] = [(snippet_arc, len(snippet_bytes), _sha256_bytes(snippet_bytes))]
-        task = progress.task("bundle: hash files", total=len(file_members) + 1, unit="files")
-        task.advance(1)
+        manifest_entries: list[tuple[str, int, str]] = [
+            (snippet_arc, len(snippet_bytes), _sha256_bytes(snippet_bytes)),
+            (validation_arc, len(validation_bytes), _sha256_bytes(validation_bytes)),
+        ]
+        task = progress.task("bundle: hash files", total=len(file_members) + 2, unit="files")
+        task.advance(2)
         for arc, p in sorted(file_members, key=lambda t: t[0]):
             manifest_entries.append((arc, p.stat().st_size, _sha256_file(p)))
             task.advance(1)
@@ -180,7 +207,7 @@ def build_share_bundle(*, run_dir: str, out_path: str) -> None:
 
     # Write deterministic tar.gz (stable gzip header mtime + stable tar metadata).
     with progress.phase("bundle: write archive"):
-        total_members = len(dir_names) + 2 + len(file_members)  # dirs + snippet + manifest + files
+        total_members = len(dir_names) + 3 + len(file_members)  # dirs + snippet + validation + manifest + files
         task = progress.task("bundle: write archive", total=total_members, unit="members")
 
         with out.open("wb") as raw:
@@ -191,6 +218,9 @@ def build_share_bundle(*, run_dir: str, out_path: str) -> None:
                         task.advance(1)
 
                     tf.addfile(_tarinfo_file(snippet_arc, size=len(snippet_bytes)), io.BytesIO(snippet_bytes))
+                    task.advance(1)
+
+                    tf.addfile(_tarinfo_file(validation_arc, size=len(validation_bytes)), io.BytesIO(validation_bytes))
                     task.advance(1)
 
                     tf.addfile(_tarinfo_file(manifest_arc, size=len(manifest_bytes)), io.BytesIO(manifest_bytes))
@@ -267,11 +297,12 @@ def verify_share_bundle(*, bundle_path: str) -> list[str]:
                     # Allow only registry dir and known files.
                     if len(p.parts) == 2:
                         continue
-                    if len(p.parts) == 3 and p.parts[2] in {_RUN_ENTRY_JSON, _BUNDLE_MANIFEST_CSV}:
+                    if len(p.parts) == 3 and p.parts[2] in {_RUN_ENTRY_JSON, _BUNDLE_MANIFEST_CSV, _VALIDATION_LOG_TXT}:
                         continue
                 errors.append(f"disallowed path: {n}")
 
             run_entry_path = f"{run_id}/{_REGISTRY_DIR}/{_RUN_ENTRY_JSON}"
+            validation_path = f"{run_id}/{_REGISTRY_DIR}/{_VALIDATION_LOG_TXT}"
             manifest_path = f"{run_id}/{_REGISTRY_DIR}/{_BUNDLE_MANIFEST_CSV}"
 
             try:
@@ -285,6 +316,17 @@ def verify_share_bundle(*, bundle_path: str) -> list[str]:
                     json.loads(run_entry_f.read().decode("utf-8"))
                 except Exception as e:
                     errors.append(f"invalid JSON: {run_entry_path}: {type(e).__name__}")
+
+            try:
+                validation_f = tf.extractfile(validation_path)
+            except KeyError:
+                validation_f = None
+            if validation_f is None:
+                errors.append(f"missing {validation_path}")
+            else:
+                text = validation_f.read().decode("utf-8", errors="replace")
+                if "HealthDelta Bundle Validation Log" not in text:
+                    errors.append(f"invalid validation log: {validation_path}")
 
             try:
                 manifest_f = tf.extractfile(manifest_path)

--- a/tests/test_share_bundle.py
+++ b/tests/test_share_bundle.py
@@ -1,5 +1,6 @@
 import io
 import json
+import csv
 import subprocess
 import sys
 import tarfile
@@ -98,6 +99,7 @@ class TestShareBundle(unittest.TestCase):
                 self.assertIn(f"{run_id}/note/doctor_note.txt", names)
                 self.assertIn(f"{run_id}/deid/source/export.xml", names)
                 self.assertIn(f"{run_id}/registry/run_entry.json", names)
+                self.assertIn(f"{run_id}/registry/validation_log.txt", names)
                 self.assertIn(f"{run_id}/registry/bundle_manifest.csv", names)
 
                 self.assertFalse(any("/staging/" in n or n.startswith(f"{run_id}/staging") for n in names))
@@ -108,6 +110,22 @@ class TestShareBundle(unittest.TestCase):
                 reg_obj = json.loads(reg.read().decode("utf-8"))
                 self.assertEqual(reg_obj.get("run_id"), run_id)
                 self.assertNotIn("notes", reg_obj)
+
+                manifest_f = tf.extractfile(f"{run_id}/registry/bundle_manifest.csv")
+                self.assertIsNotNone(manifest_f)
+                manifest_rows = list(csv.DictReader(manifest_f.read().decode("utf-8").splitlines()))
+                by_path = {r["path"]: r for r in manifest_rows}
+                required = [
+                    f"{run_id}/ndjson/observations.ndjson",
+                    f"{run_id}/duckdb/run.duckdb",
+                    f"{run_id}/reports/summary.json",
+                    f"{run_id}/note/doctor_note.txt",
+                    f"{run_id}/registry/run_entry.json",
+                    f"{run_id}/registry/validation_log.txt",
+                ]
+                for req in required:
+                    self.assertIn(req, by_path)
+                    self.assertEqual(len(by_path[req]["sha256"]), 64)
 
     def test_share_verify_rejects_disallowed_paths(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Issue: #85

Extends the share bundle to include deterministic evidence validation logs.

## What changed
- Added `registry/validation_log.txt` to bundle output and deterministic manifest coverage.
- Extended bundle verifier to require and validate the new validation log artifact.
- Added/updated tests to assert required evidence files and manifest SHA256 entries.
- Preserved deterministic archive behavior and existing allowlist protections.

## Validation
- `TZ=UTC python3 -m unittest tests/test_share_bundle.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #85
