### PR TITLE
CI: enforce audit logs + evidence artifacts

### DIFF
--- a/.ai/prompts/issue_86.md
+++ b/.ai/prompts/issue_86.md
@@ -1,0 +1,17 @@
+---
+Story
+As a maintainer,
+I want CI to enforce that every change has evidence artifacts and updated audit logs,
+So that governance and correctness are programmatically guaranteed.
+
+Context / Why
+Guardrails must be as strict as the policy demands.
+
+Acceptance Criteria
+- CI fails if `.ai/time/time.csv` or `.ai/sessions/` is not updated for code changes.
+- CI uploads evidence artifacts (test logs, validation reports).
+- Tests/CI steps are documented and deterministic.
+
+Out of Scope
+- Historical backfill beyond current changes.
+---

--- a/.ai/sessions/2026-02-01/session_11.md
+++ b/.ai/sessions/2026-02-01/session_11.md
@@ -1,0 +1,16 @@
+# Session 11 — 2026-02-01
+
+Issue: #86
+
+Goal
+- Tighten CI governance guardrails and evidence artifact capture.
+
+Notes
+- Strengthened audit-artifact gate to require modified `.ai/time/time.csv` and updated session files that reference the active issue.
+- Added NDJSON validation smoke evidence log upload in CI artifacts.
+- Converted audit-artifact tests to `unittest` so they run in existing CI discovery flow.
+- Updated CD runbook with deterministic Linux evidence artifact expectations.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -74,3 +74,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,83,,20,codex,,"duckdb/report/note coverage for diagnostic report stream"
 2026-02-01,84,,25,codex,,"share-safe source_system tagging through export, duckdb, and reports"
 2026-02-01,85,,20,codex,,"share bundle evidence pack with validation log + manifest checks"
+2026-02-01,86,,25,codex,,"CI guardrails for audit updates + validation evidence artifacts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,17 @@ jobs:
 
           echo "UNITTEST_EXIT=$unittest_exit" >> "$GITHUB_ENV"
 
+      - name: Run NDJSON validation smoke (artifact evidence)
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/linux
+          tmpdir="$(mktemp -d)"
+          cat > "$tmpdir/observations.ndjson" <<'EOF'
+          {"schema_version":2,"record_key":"rk1","canonical_person_id":"person-1","source":"fhir","source_system":"ss_smoke000001","source_file":"source/clinical/obs.json","event_time":"2020-01-01T00:00:00Z","run_id":"run-smoke"}
+          EOF
+          python3 -m healthdelta export validate --input "$tmpdir" > artifacts/linux/ndjson_validate.log 2>&1
+          rm -rf "$tmpdir"
+
       - name: Upload Linux unittest artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -64,6 +75,7 @@ jobs:
           path: |
             artifacts/linux/python_version.txt
             artifacts/linux/unittest.log
+            artifacts/linux/ndjson_validate.log
           if-no-files-found: error
 
       - name: Fail if unittest failed

--- a/docs/runbook_cd.md
+++ b/docs/runbook_cd.md
@@ -8,6 +8,9 @@ This runbook defines how HealthDelta produces share-safe build artifacts and wha
 - Workflow: `.github/workflows/ci.yml`
 - Proof:
   - Linux job passes (non-iOS tests).
+  - Linux uploads deterministic evidence artifacts:
+    - `linux-unittest` (`python_version.txt`, `unittest.log`)
+    - `ndjson_validate.log` smoke validation output
   - macOS job passes and uploads `ios-xcresult`.
 
 ### Release (artifact publication)

--- a/scripts/check_audit_artifacts.py
+++ b/scripts/check_audit_artifacts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import csv
-import datetime as dt
 import os
 import re
 import subprocess
@@ -11,6 +10,7 @@ import sys
 from pathlib import Path
 
 ISSUE_NUMBER_RE = re.compile(r"Issue:\s*#(\d+)\s*$", re.MULTILINE)
+SESSION_PATH_RE = re.compile(r"^\.ai/sessions/\d{4}-\d{2}-\d{2}/session_\d+\.md$")
 
 
 def extract_issue_numbers(message: str) -> list[str]:
@@ -41,6 +41,29 @@ def time_csv_has_issue(path: Path, issue_no: str) -> bool:
     return False
 
 
+def time_csv_updated(paths: list[str]) -> bool:
+    return ".ai/time/time.csv" in paths
+
+
+def updated_session_paths(paths: list[str]) -> list[Path]:
+    out: list[Path] = []
+    for p in paths:
+        if SESSION_PATH_RE.match(p):
+            out.append(Path(p))
+    return out
+
+
+def session_paths_have_issue(paths: list[Path], issue_no: str) -> bool:
+    marker = f"Issue: #{issue_no}"
+    for p in paths:
+        if not p.exists():
+            continue
+        text = p.read_text(encoding="utf-8", errors="replace")
+        if marker in text:
+            return True
+    return False
+
+
 def _git(*args: str) -> str:
     return subprocess.check_output(["git", *args], text=True).strip()
 
@@ -67,11 +90,6 @@ def _commit_messages() -> list[str]:
     return [_git("log", "-1", "--format=%B", sha) for sha in commits]
 
 
-def _today_session_dir() -> Path:
-    today = dt.date.today().isoformat()
-    return Path(".ai") / "sessions" / today
-
-
 def main() -> int:
     paths = _changed_paths()
     if not has_non_ai_changes(paths):
@@ -89,14 +107,22 @@ def main() -> int:
         print(f"Missing prompt file: {prompt_path}")
         return 1
 
-    session_dir = _today_session_dir()
-    if not session_dir.exists() or not any(session_dir.iterdir()):
-        print(f"Missing session entry for today: {session_dir}")
+    if not time_csv_updated(paths):
+        print("Missing required file update for code changes: .ai/time/time.csv")
+        return 1
+
+    session_paths = updated_session_paths(paths)
+    if not session_paths:
+        print("Missing required session update for code changes under .ai/sessions/YYYY-MM-DD/session_N.md")
         return 1
 
     time_csv = Path(".ai") / "time" / "time.csv"
     if not time_csv_has_issue(time_csv, issue_no):
         print(f"Missing time.csv entry for Issue #{issue_no}")
+        return 1
+
+    if not session_paths_have_issue(session_paths, issue_no):
+        print(f"No updated session entry references Issue #{issue_no}")
         return 1
 
     print("Audit artifact check passed.")

--- a/tests/test_audit_artifacts.py
+++ b/tests/test_audit_artifacts.py
@@ -1,4 +1,6 @@
 import importlib.util
+import os
+import unittest
 from pathlib import Path
 
 
@@ -11,27 +13,64 @@ def _load_module():
     return module
 
 
-def test_select_single_issue():
-    mod = _load_module()
-    msgs = ["Change\n\nIssue: #72\n", "Other\n\nIssue: #72\n"]
-    assert mod.select_single_issue(msgs) == "72"
+class TestAuditArtifacts(unittest.TestCase):
+    def test_select_single_issue(self) -> None:
+        mod = _load_module()
+        msgs = ["Change\n\nIssue: #72\n", "Other\n\nIssue: #72\n"]
+        self.assertEqual(mod.select_single_issue(msgs), "72")
+
+    def test_select_single_issue_rejects_multiple(self) -> None:
+        mod = _load_module()
+        msgs = ["Issue: #72\n", "Issue: #73\n"]
+        self.assertIsNone(mod.select_single_issue(msgs))
+
+    def test_has_non_ai_changes(self) -> None:
+        mod = _load_module()
+        self.assertFalse(mod.has_non_ai_changes([".ai/time/time.csv"]))
+        self.assertTrue(mod.has_non_ai_changes(["docs/plan.md"]))
+
+    def test_time_csv_has_issue(self) -> None:
+        mod = _load_module()
+        with self.subTest("match"):
+            with self.subTest("temp"):
+                p = Path(self._tmp_dir()) / "time.csv"
+                p.write_text("2026-01-30,72,,5,codex,,note\n", encoding="utf-8")
+                self.assertTrue(mod.time_csv_has_issue(p, "72"))
+                self.assertFalse(mod.time_csv_has_issue(p, "73"))
+
+    def test_time_csv_updated(self) -> None:
+        mod = _load_module()
+        self.assertTrue(mod.time_csv_updated([".ai/time/time.csv"]))
+        self.assertFalse(mod.time_csv_updated(["docs/plan.md"]))
+
+    def test_updated_session_paths_and_issue(self) -> None:
+        mod = _load_module()
+        root = Path(self._tmp_dir())
+        p = root / ".ai" / "sessions" / "2026-02-01" / "session_1.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# Session\n\nIssue: #86\n", encoding="utf-8")
+
+        rel = p.relative_to(root).as_posix()
+        paths = [rel, "docs/plan.md"]
+        session_paths = mod.updated_session_paths(paths)
+        self.assertEqual(session_paths, [Path(rel)])
+
+        old_cwd = Path.cwd()
+        try:
+            os.chdir(root)
+            self.assertTrue(mod.session_paths_have_issue(session_paths, "86"))
+            self.assertFalse(mod.session_paths_have_issue(session_paths, "85"))
+        finally:
+            os.chdir(old_cwd)
+
+    def _tmp_dir(self) -> str:
+        import tempfile
+
+        if not hasattr(self, "_td"):
+            self._td = tempfile.TemporaryDirectory()
+            self.addCleanup(self._td.cleanup)
+        return self._td.name
 
 
-def test_select_single_issue_rejects_multiple():
-    mod = _load_module()
-    msgs = ["Issue: #72\n", "Issue: #73\n"]
-    assert mod.select_single_issue(msgs) is None
-
-
-def test_has_non_ai_changes():
-    mod = _load_module()
-    assert mod.has_non_ai_changes([".ai/time/time.csv"]) is False
-    assert mod.has_non_ai_changes(["docs/plan.md"]) is True
-
-
-def test_time_csv_has_issue(tmp_path: Path):
-    mod = _load_module()
-    p = tmp_path / "time.csv"
-    p.write_text("2026-01-30,72,,5,codex,,note\n", encoding="utf-8")
-    assert mod.time_csv_has_issue(p, "72") is True
-    assert mod.time_csv_has_issue(p, "73") is False
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #86

Hardens CI guardrails for governance and evidence artifacts.

## What changed
- Strengthened `check_audit_artifacts.py` to require, for code changes:
  - `.ai/time/time.csv` is part of the change set
  - at least one updated session file under `.ai/sessions/YYYY-MM-DD/session_N.md`
  - updated session content references the active issue number
- Added CI evidence step that runs NDJSON validation smoke and uploads `artifacts/linux/ndjson_validate.log`.
- Converted audit-artifact tests to `unittest` so they execute in existing CI `unittest discover` flow.
- Updated `docs/runbook_cd.md` with deterministic CI evidence artifact expectations.

## Validation
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #86
