### PR TITLE
Issue: #117 managed worktree root + auto-prune guardrails

### DIFF
--- a/.ai/prompts/issue_117.md
+++ b/.ai/prompts/issue_117.md
@@ -1,0 +1,22 @@
+---
+Story
+As a maintainer,
+I want issue-scoped worktrees to be created in a dedicated hidden workspace with automatic pruning,
+So that local workflows stay clean while preserving isolated branch safety.
+
+Context / Why
+Issue-scoped worktrees currently appear as sibling folders in `~/Code`, causing clutter and confusion. The method should be enforced by infrastructure code, not informal process notes, and should automatically clean stale/merged worktrees.
+
+Acceptance Criteria
+- A repo-managed script creates issue worktrees under a dedicated hidden root (not sibling `HealthDelta-issue##` folders).
+- A repo-managed prune command removes merged/closed issue worktrees automatically.
+- A CI/local guardrail fails when prohibited sibling worktree paths are used by the managed workflow metadata.
+- Runbook docs describe deterministic usage and cleanup commands.
+- Tests validate path derivation, create/prune selection logic, and policy checks.
+
+Out of Scope
+- Managing arbitrary non-issue worktrees outside the managed workflow.
+
+Notes
+- This is governance + developer-experience infrastructure; AGENTS.md may reference the workflow but must not be the source of enforcement.
+---

--- a/.ai/sessions/2026-02-01/session_12.md
+++ b/.ai/sessions/2026-02-01/session_12.md
@@ -1,0 +1,17 @@
+# Session 12 — 2026-02-01
+
+Issue: #117
+
+Goal
+- Enforce managed issue worktree location and automate stale worktree pruning.
+
+Notes
+- Added `scripts/worktree_manager.py` with `create`, `prune`, and `check` commands.
+- Added `healthdelta/worktree_policy.py` for deterministic path policy and prune candidate selection logic.
+- Added CI guardrail step to fail when legacy sibling worktree paths are used.
+- Added `docs/runbook_worktree.md` and `tests/test_worktree_policy.py`.
+
+Local verification
+- python3 -m unittest tests/test_worktree_policy.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v
+- python3 scripts/worktree_manager.py check

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -75,3 +75,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,84,,25,codex,,"share-safe source_system tagging through export, duckdb, and reports"
 2026-02-01,85,,20,codex,,"share bundle evidence pack with validation log + manifest checks"
 2026-02-01,86,,25,codex,,"CI guardrails for audit updates + validation evidence artifacts"
+2026-02-01,117,,45,codex,,"Managed issue worktree root + auto-prune policy guardrails"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
           set -euo pipefail
           python3 scripts/check_prompt_immutability.py
 
+      - name: Enforce managed worktree policy
+        run: |
+          set -euo pipefail
+          python3 scripts/worktree_manager.py check
+
       - name: Install Python dependencies
         run: |
           set -euo pipefail

--- a/docs/runbook_worktree.md
+++ b/docs/runbook_worktree.md
@@ -1,0 +1,63 @@
+# Runbook: Managed Issue Worktrees
+
+This runbook defines the enforced worktree lifecycle for issue-scoped development.
+
+## Why
+
+- Keep `~/Code` clean (no `HealthDelta-issue##` sibling directories).
+- Preserve isolated issue branches/workspaces.
+- Prune stale worktrees automatically when issue + merge lifecycle is complete.
+
+## Managed location
+
+Default root:
+
+- `<repo-parent>/.worktrees/<repo-name>/`
+- Example for this repo: `~/Code/.worktrees/HealthDelta/`
+
+Override root (optional):
+
+- `HEALTHDELTA_WORKTREE_ROOT=/path/to/root`
+
+## Commands
+
+From repo root:
+
+```bash
+python3 scripts/worktree_manager.py create --issue 117
+python3 scripts/worktree_manager.py prune
+python3 scripts/worktree_manager.py check
+```
+
+### Behavior
+
+- `create`
+  - auto-prunes first (unless `--no-auto-prune`)
+  - creates or reuses branch `issue-N`
+  - creates worktree at `<managed-root>/issue-N`
+- `prune`
+  - removes managed issue worktrees when:
+    - GitHub issue is closed, and
+    - issue branch is merged into `origin/main`
+- `check`
+  - fails on legacy sibling pattern: `~/Code/HealthDelta-issue##`
+  - fails when issue branches live outside managed root
+
+## CI guardrail
+
+CI runs `python3 scripts/worktree_manager.py check` to enforce path policy.
+
+## Migration
+
+If legacy sibling worktrees exist:
+
+```bash
+python3 scripts/worktree_manager.py prune
+```
+
+If needed, remove legacy paths manually via:
+
+```bash
+git worktree remove -f /path/to/legacy/worktree
+git worktree prune
+```

--- a/healthdelta/worktree_policy.py
+++ b/healthdelta/worktree_policy.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def managed_root(repo_root: Path, configured_root: str | None = None) -> Path:
+    if configured_root:
+        return Path(configured_root).expanduser().resolve()
+    # Default: keep issue worktrees out of ~/Code clutter.
+    return (repo_root.parent / ".worktrees" / repo_root.name).resolve()
+
+
+def issue_branch(issue_no: int) -> str:
+    return f"issue-{issue_no}"
+
+
+def issue_worktree_path(root: Path, issue_no: int) -> Path:
+    return root / issue_branch(issue_no)
+
+
+@dataclass(frozen=True)
+class WorktreeRef:
+    path: Path
+    branch: str | None
+
+
+def parse_worktree_porcelain(text: str) -> list[WorktreeRef]:
+    out: list[WorktreeRef] = []
+    path: Path | None = None
+    branch: str | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("worktree "):
+            if path is not None:
+                out.append(WorktreeRef(path=path, branch=branch))
+            path = Path(line.split(" ", 1)[1])
+            branch = None
+            continue
+        if line.startswith("branch "):
+            ref = line.split(" ", 1)[1]
+            branch = ref.removeprefix("refs/heads/")
+    if path is not None:
+        out.append(WorktreeRef(path=path, branch=branch))
+    return out
+
+
+def is_legacy_issue_sibling(path: Path, repo_root: Path) -> bool:
+    name = path.name
+    if not name.startswith(f"{repo_root.name}-issue"):
+        return False
+    return path.parent == repo_root.parent
+
+
+def issue_no_from_branch(branch: str | None) -> int | None:
+    if not isinstance(branch, str):
+        return None
+    if not branch.startswith("issue-"):
+        return None
+    suffix = branch.split("-", 1)[1]
+    return int(suffix) if suffix.isdigit() else None
+
+
+def select_prune_candidates(
+    *,
+    worktrees: list[WorktreeRef],
+    repo_root: Path,
+    root: Path,
+    closed_issues: set[int],
+    merged_branches: set[str],
+) -> list[WorktreeRef]:
+    candidates: list[WorktreeRef] = []
+    for wt in worktrees:
+        if wt.path == repo_root:
+            continue
+        if not str(wt.path).startswith(str(root)):
+            continue
+        issue_no = issue_no_from_branch(wt.branch)
+        if issue_no is None:
+            continue
+        if issue_no in closed_issues and wt.branch in merged_branches:
+            candidates.append(wt)
+    return sorted(candidates, key=lambda x: str(x.path))

--- a/scripts/worktree_manager.py
+++ b/scripts/worktree_manager.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Managed issue-worktree lifecycle (create/prune/policy-check)."""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from healthdelta.worktree_policy import (
+    is_legacy_issue_sibling,
+    issue_branch,
+    issue_no_from_branch,
+    issue_worktree_path,
+    managed_root,
+    parse_worktree_porcelain,
+    select_prune_candidates,
+)
+
+
+def _run(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_output(repo_root: Path, *args: str) -> str:
+    return _run(repo_root, *args).stdout.strip()
+
+
+def _worktrees(repo_root: Path):
+    text = _git_output(repo_root, "worktree", "list", "--porcelain")
+    return parse_worktree_porcelain(text)
+
+
+def _issue_is_closed(repo: str, issue_no: int) -> bool:
+    p = subprocess.run(
+        ["gh", "issue", "view", str(issue_no), "--repo", repo, "--json", "state", "--jq", ".state"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return p.returncode == 0 and p.stdout.strip().upper() == "CLOSED"
+
+
+def _branch_merged(repo_root: Path, branch: str) -> bool:
+    p = _run(repo_root, "merge-base", "--is-ancestor", branch, "origin/main", check=False)
+    return p.returncode == 0
+
+
+def cmd_create(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    root = managed_root(repo_root, args.root)
+    root.mkdir(parents=True, exist_ok=True)
+
+    _run(repo_root, "fetch", "origin")
+    if not args.no_auto_prune:
+        _prune(repo_root=repo_root, root=root, repo=args.repo)
+    branch = issue_branch(args.issue)
+    target = issue_worktree_path(root, args.issue)
+    if target.exists():
+        print(f"exists: {target}")
+        return 0
+
+    has_branch = _run(repo_root, "rev-parse", "--verify", f"refs/heads/{branch}", check=False).returncode == 0
+    if has_branch:
+        _run(repo_root, "worktree", "add", str(target), branch)
+    else:
+        _run(repo_root, "worktree", "add", "-b", branch, str(target), "origin/main")
+    print(str(target))
+    return 0
+
+
+def _prune(*, repo_root: Path, root: Path, repo: str) -> int:
+    if not root.exists():
+        return 0
+
+    _run(repo_root, "fetch", "origin")
+    refs = _worktrees(repo_root)
+    issue_nos = sorted({n for n in (issue_no_from_branch(w.branch) for w in refs) if n is not None})
+    closed = {n for n in issue_nos if _issue_is_closed(repo, n)}
+    merged = {w.branch for w in refs if isinstance(w.branch, str) and _branch_merged(repo_root, w.branch)}
+    candidates = select_prune_candidates(
+        worktrees=refs,
+        repo_root=repo_root,
+        root=root,
+        closed_issues=closed,
+        merged_branches=merged,
+    )
+    for wt in candidates:
+        _run(repo_root, "worktree", "remove", "-f", str(wt.path))
+        print(f"pruned {wt.path}")
+    _run(repo_root, "worktree", "prune")
+    return 0
+
+
+def cmd_prune(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    root = managed_root(repo_root, args.root)
+    rc = _prune(repo_root=repo_root, root=root, repo=args.repo)
+    if not root.exists():
+        print("nothing to prune")
+    else:
+        print("prune complete")
+    return rc
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    root = managed_root(repo_root, args.root)
+    refs = _worktrees(repo_root)
+    errors: list[str] = []
+    for wt in refs:
+        if wt.path == repo_root:
+            continue
+        if is_legacy_issue_sibling(wt.path, repo_root):
+            errors.append(f"legacy sibling worktree path is disallowed: {wt.path}")
+        issue_no = issue_no_from_branch(wt.branch)
+        if issue_no is not None and not str(wt.path).startswith(str(root)):
+            errors.append(f"issue worktree must live under {root}: {wt.path}")
+    if errors:
+        for e in errors:
+            print(e)
+        return 1
+    print("worktree policy check passed")
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Manage issue worktrees in a hidden root.")
+    p.add_argument("--repo-root", default=os.getcwd(), help="Repository root (default: cwd).")
+    p.add_argument("--root", default=os.getenv("HEALTHDELTA_WORKTREE_ROOT"), help="Managed worktree root path.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("create", help="Create issue worktree under managed root.")
+    c.add_argument("--issue", required=True, type=int)
+    c.add_argument("--repo", default="dave0875/HealthDelta", help="GitHub repo for issue state lookup when auto-pruning.")
+    c.add_argument("--no-auto-prune", action="store_true", help="Skip auto-prune before creating worktree.")
+    c.set_defaults(fn=cmd_create)
+
+    pr = sub.add_parser("prune", help="Prune closed+merged issue worktrees under managed root.")
+    pr.add_argument("--repo", default="dave0875/HealthDelta", help="GitHub repo for issue state lookup.")
+    pr.set_defaults(fn=cmd_prune)
+
+    ck = sub.add_parser("check", help="Enforce worktree path policy.")
+    ck.set_defaults(fn=cmd_check)
+    return p
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_worktree_policy.py
+++ b/tests/test_worktree_policy.py
@@ -1,0 +1,62 @@
+import unittest
+from pathlib import Path
+
+from healthdelta.worktree_policy import (
+    WorktreeRef,
+    is_legacy_issue_sibling,
+    managed_root,
+    parse_worktree_porcelain,
+    select_prune_candidates,
+)
+
+
+class TestWorktreePolicy(unittest.TestCase):
+    def test_managed_root_default_and_override(self) -> None:
+        repo = Path("/home/user/Code/HealthDelta")
+        self.assertEqual(managed_root(repo), Path("/home/user/Code/.worktrees/HealthDelta"))
+        self.assertEqual(managed_root(repo, "/tmp/hd"), Path("/tmp/hd"))
+
+    def test_parse_worktree_porcelain(self) -> None:
+        text = "\n".join(
+            [
+                "worktree /repo",
+                "HEAD abc",
+                "branch refs/heads/main",
+                "worktree /repo/.worktrees/issue-10",
+                "HEAD def",
+                "branch refs/heads/issue-10",
+            ]
+        )
+        refs = parse_worktree_porcelain(text)
+        self.assertEqual(len(refs), 2)
+        self.assertEqual(refs[0].path, Path("/repo"))
+        self.assertEqual(refs[0].branch, "main")
+        self.assertEqual(refs[1].branch, "issue-10")
+
+    def test_is_legacy_issue_sibling(self) -> None:
+        repo = Path("/home/user/Code/HealthDelta")
+        self.assertTrue(is_legacy_issue_sibling(Path("/home/user/Code/HealthDelta-issue99"), repo))
+        self.assertFalse(is_legacy_issue_sibling(Path("/home/user/Code/.worktrees/HealthDelta/issue-99"), repo))
+
+    def test_select_prune_candidates_closed_and_merged(self) -> None:
+        repo = Path("/repo")
+        root = Path("/repo/.worktrees")
+        refs = [
+            WorktreeRef(path=repo, branch="main"),
+            WorktreeRef(path=Path("/repo/.worktrees/issue-10"), branch="issue-10"),
+            WorktreeRef(path=Path("/repo/.worktrees/issue-11"), branch="issue-11"),
+            WorktreeRef(path=Path("/repo/.worktrees/topic"), branch="topic"),
+            WorktreeRef(path=Path("/repo/HealthDelta-issue12"), branch="issue-12"),
+        ]
+        got = select_prune_candidates(
+            worktrees=refs,
+            repo_root=repo,
+            root=root,
+            closed_issues={10, 11, 12},
+            merged_branches={"issue-10", "issue-12"},
+        )
+        self.assertEqual([x.branch for x in got], ["issue-10"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #117

## What
- add `scripts/worktree_manager.py` with `create`, `prune`, and `check` commands
- add `healthdelta/worktree_policy.py` for deterministic policy helpers
- enforce worktree path policy in CI (`python3 scripts/worktree_manager.py check`)
- document deterministic usage in `docs/runbook_worktree.md`
- add unit coverage in `tests/test_worktree_policy.py`
- add required audit artifacts for issue #117

## Validation
- `python3 -m unittest tests/test_worktree_policy.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`
- `python3 scripts/worktree_manager.py check`

Closes #117
