### PR TITLE
Issue: #120 plan Orin production deployment MMF phase

### DIFF
--- a/.ai/prompts/issue_120.md
+++ b/.ai/prompts/issue_120.md
@@ -1,0 +1,23 @@
+---
+Story
+As an operator,
+I want an issue-backed, phased plan for production deployment on `orin.local` (Jetson Orin Nano Super),
+So that we can ship a local-only backend analytics target with auditable, incremental MMFs.
+
+Context / Why
+A super prompt exists for Jetson-focused local medical analytics planning, but the repo needs this translated into HealthDelta issue backlog, deployment milestones, and runbook-ready acceptance criteria. Without this planning phase, deployment work will be ad hoc and difficult to validate.
+
+Acceptance Criteria
+- Given the Jetson super prompt and current repository state, when planning is completed, then a prioritized MMF backlog is published as GitHub issues using the required template.
+- Given the new MMF backlog, when docs are updated, then `docs/plan.md` includes an explicit "Orin production deployment" phase with ordered issue links.
+- Given backend deployment scope, when runbook planning docs are updated, then `docs/runbook_cd.md` includes Orin-specific deployment-proof criteria (what CI/job/artifact proves readiness).
+- Given governance requirements, when this planning issue is executed, then `.ai/prompts/issue_N.md`, `.ai/sessions/`, and `.ai/time/time.csv` are updated for the active issue.
+
+Out of Scope
+- Implementing Orin deployment code, infra, or runtime tuning.
+- Operating remote shell on `orin.local`.
+
+Notes
+- Planning must preserve local-only inference and share-safe output constraints.
+- Backlog should prioritize risk flags and summaries before trends and Q&A.
+---

--- a/.ai/sessions/2026-02-01/session_13.md
+++ b/.ai/sessions/2026-02-01/session_13.md
@@ -1,0 +1,17 @@
+# Session 13 - 2026-02-01
+
+Issue: #120
+
+Goal
+- Create an issue-backed planning phase for Orin (`orin.local`) production deployment using the provided super prompt.
+
+Notes
+- Created planning issue #120 with required template.
+- Created prioritized Orin MMF backlog issues #121-#128 using required template structure.
+- Updated `docs/plan.md` to add the Orin deployment phase and issue links.
+- Updated `docs/runbook_cd.md` with Orin deployment-proof criteria (CI/job/artifact + smoke + rollback evidence).
+
+Local verification
+- gh issue view 120 --repo dave0875/HealthDelta --json number,title,state,url
+- gh issue view 121 --repo dave0875/HealthDelta --json number,title,state,url
+- gh issue view 128 --repo dave0875/HealthDelta --json number,title,state,url

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -76,3 +76,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,85,,20,codex,,"share bundle evidence pack with validation log + manifest checks"
 2026-02-01,86,,25,codex,,"CI guardrails for audit updates + validation evidence artifacts"
 2026-02-01,117,,45,codex,,"Managed issue worktree root + auto-prune policy guardrails"
+2026-02-01,120,,35,codex,,"Orin production deployment planning phase + MMF backlog"

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -43,40 +43,34 @@ CI proof is mandatory:
 These issues are intended as small vertical slices.
 
 Completed
-- Issues #1–#69 (bootstrap through CLI progress + CD, including iOS incremental export pipeline) are closed.
-- Issues #33–#42 (plan refresh, iOS deterministic exports, staging, DuckDB/reporting, and ADR convergence) are closed.
+- Issues #1-#86 are closed (bootstrap through governance/evidence guardrails for FHIR, NDJSON, reporting, and CI policy enforcement).
+- Issue #117 is closed (managed hidden worktree root + auto-prune + CI path guardrail).
 
-Next (priority order)
-1) Issue #72 — Governance: plan refresh + CI issue reference gate (in progress)
+Active governance carryover
+1) Issue #72 - Governance: plan refresh + CI issue reference gate
    - https://github.com/dave0875/HealthDelta/issues/72
-2) Issue #73 — FHIR export: Encounter
-   - https://github.com/dave0875/HealthDelta/issues/73
-3) Issue #74 — FHIR export: Procedure
-   - https://github.com/dave0875/HealthDelta/issues/74
-4) Issue #75 — FHIR export: DiagnosticReport (+ Observation linkage)
-   - https://github.com/dave0875/HealthDelta/issues/75
-5) Issue #76 — FHIR export: MedicationStatement + MedicationDispense
-   - https://github.com/dave0875/HealthDelta/issues/76
-6) Issue #77 — FHIR export: AllergyIntolerance + Immunization
-   - https://github.com/dave0875/HealthDelta/issues/77
-7) Issue #78 — Identity: subject.identifier resolution
-   - https://github.com/dave0875/HealthDelta/issues/78
-8) Issue #79 — Reporting: unresolved reference integrity report
-   - https://github.com/dave0875/HealthDelta/issues/79
-9) Issue #80 — De-id: scrub FHIR free-text/narrative
-   - https://github.com/dave0875/HealthDelta/issues/80
-10) Issue #81 — CDA export: discharge summary coverage
-   - https://github.com/dave0875/HealthDelta/issues/81
-11) Issue #82 — NDJSON: JSON schema + CI validation
-   - https://github.com/dave0875/HealthDelta/issues/82
-12) Issue #83 — DuckDB/reporting: include new FHIR types
-   - https://github.com/dave0875/HealthDelta/issues/83
-13) Issue #84 — Provenance: share-safe source_system tagging
-   - https://github.com/dave0875/HealthDelta/issues/84
-14) Issue #85 — Share bundle: hospital record evidence pack
-   - https://github.com/dave0875/HealthDelta/issues/85
-15) Issue #86 — CI: enforce audit logs + evidence artifacts
-   - https://github.com/dave0875/HealthDelta/issues/86
+2) Issue #92 - Governance: CI guardrails for issue discipline
+   - https://github.com/dave0875/HealthDelta/issues/92
+
+New planning phase: Orin production deployment target (`orin.local`)
+3) Issue #120 - Planning: Orin production deployment MMF backlog
+   - https://github.com/dave0875/HealthDelta/issues/120
+4) Issue #121 - Orin MMF: export inventory + PHI field map
+   - https://github.com/dave0875/HealthDelta/issues/121
+5) Issue #122 - Orin MMF: local model/runtime matrix for summaries + risk flags
+   - https://github.com/dave0875/HealthDelta/issues/122
+6) Issue #123 - Orin MMF: ingest-to-summary vertical slice on backend
+   - https://github.com/dave0875/HealthDelta/issues/123
+7) Issue #124 - Orin MMF: risk flags v1 with evidence + disclaimers
+   - https://github.com/dave0875/HealthDelta/issues/124
+8) Issue #125 - Orin MMF: trend analysis v1 for longitudinal records
+   - https://github.com/dave0875/HealthDelta/issues/125
+9) Issue #126 - Orin MMF: grounded Q&A v1 with abstain behavior
+   - https://github.com/dave0875/HealthDelta/issues/126
+10) Issue #127 - Orin MMF: production deployment + rollback proof on orin.local
+    - https://github.com/dave0875/HealthDelta/issues/127
+11) Issue #128 - Orin MMF: CI safety guardrails for PHI leakage + disclosure requirements
+    - https://github.com/dave0875/HealthDelta/issues/128
 
 ## Operating rules (quick reference)
 

--- a/docs/runbook_cd.md
+++ b/docs/runbook_cd.md
@@ -49,7 +49,20 @@ Note: CLI packaging version is tag-derived; do not manually edit a fixed `versio
 - Local dev (Compose): `docker compose -f compose.backend.dev.yaml up --build`
 - Version injection for containers:
   - Build args: `HEALTHDELTA_VERSION`, `HEALTHDELTA_GIT_SHA`
-  - Runtime env vars: `HEALTHDELTA_VERSION`, `HEALTHDELTA_GIT_SHA`
+- Runtime env vars: `HEALTHDELTA_VERSION`, `HEALTHDELTA_GIT_SHA`
+
+## Orin production target (planning baseline)
+
+Target host: `orin.local` (Jetson Orin Nano Super, local-only analytics).
+
+Deployment proof for Orin-target issues must include:
+- CI workflow/job evidence for build + tests tied to the issue.
+- Artifact evidence for deployment package contents and version metadata.
+- Smoke verification evidence from target-compatible run steps (`/healthz`, `/version`, and issue-scoped endpoint checks).
+- Rollback procedure evidence that restores a known-good version deterministically.
+
+Planning/sequence is tracked by:
+- `docs/plan.md` Orin phase issues: #120-#128.
 
 ## References
 - Production targets ADR: `docs/adr/ADR_5_continuous_deployment_targets.md`


### PR DESCRIPTION
Issue: #120

## What
- integrated the provided Orin super-prompt intent into an issue-backed planning phase
- created new MMF backlog issues #121-#128 for local-only Orin deployment progression
- refreshed `docs/plan.md` to include the Orin deployment phase and ordered links
- updated `docs/runbook_cd.md` with explicit Orin deployment-proof criteria
- added required `.ai` audit artifacts for issue #120

## Validation
- `gh issue view 120 --repo dave0875/HealthDelta --json number,title,state,url`
- `gh issue view 121 --repo dave0875/HealthDelta --json number,title,state,url`
- `gh issue view 128 --repo dave0875/HealthDelta --json number,title,state,url`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`

Closes #120
