### PR TITLE
Issue: #132 ORIN runner diagnostics proof workflow

### DIFF
--- a/.ai/prompts/issue_132.md
+++ b/.ai/prompts/issue_132.md
@@ -1,0 +1,22 @@
+---
+Story
+As a maintainer,
+I want a reproducible ORIN runner diagnostics proof job,
+So that we can verify GitHub scheduling and runtime prerequisites on `self-hosted, linux, orin` before deployment.
+
+Context / Why
+Current ORIN deployment capability is documented but unproven by recent runs. We need a safe, idempotent diagnostics workflow that demonstrates runner scheduling and captures machine evidence artifacts.
+
+Acceptance Criteria
+- Given a workflow dispatch, when diagnostics run, then job executes on `runs-on: [self-hosted, linux, orin]`.
+- Logs include `uname -a`, `arch`, `docker --version`, and `docker compose version`.
+- A deterministic artifact `orin-runner-env` is uploaded containing `env.txt` with those values.
+- Diagnostics run does not attempt deployment and is safe to rerun.
+
+Out of Scope
+- Image publishing changes.
+- Container deployment actions.
+
+Notes
+- Keep implementation tightly scoped to runner proof only.
+---

--- a/.ai/sessions/2026-02-01/session_15.md
+++ b/.ai/sessions/2026-02-01/session_15.md
@@ -1,0 +1,15 @@
+# Session 15 - 2026-02-01
+
+Issue: #132
+
+Goal
+- Add a safe ORIN diagnostics workflow that proves runner scheduling and uploads environment evidence.
+
+Notes
+- Added `.github/workflows/orin_runner_diagnostics.yml` with `runs-on: [self-hosted, linux, orin]`.
+- Captures `uname -a`, `arch`, `docker --version`, and `docker compose version`.
+- Uploads deterministic artifact `orin-runner-env` with `artifacts/orin/env.txt`.
+- Updated `docs/runbook_orin_deploy.md` with diagnostics workflow usage.
+
+Local verification
+- YAML lint/parse by GitHub Actions on PR

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -78,3 +78,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,117,,45,codex,,"Managed issue worktree root + auto-prune policy guardrails"
 2026-02-01,120,,35,codex,,"Orin production deployment planning phase + MMF backlog"
 2026-02-01,130,,55,codex,,"Governance hardening for rewrite-tolerant non-blocking enforcement"
+2026-02-01,132,UNASSIGNED,25,codex,UNASSIGNED,"ORIN runner diagnostics workflow + evidence artifact"

--- a/.github/workflows/orin_runner_diagnostics.yml
+++ b/.github/workflows/orin_runner_diagnostics.yml
@@ -1,0 +1,32 @@
+name: ORIN Runner Diagnostics
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: orin-runner-diagnostics
+  cancel-in-progress: false
+
+jobs:
+  diagnostics:
+    name: ORIN diagnostics proof
+    runs-on: [self-hosted, linux, orin]
+    steps:
+      - name: Collect ORIN environment diagnostics
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/orin
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "uname=$(uname -a)"
+            echo "arch=$(arch)"
+            echo "docker_version=$(docker --version)"
+            echo "docker_compose_version=$(docker compose version)"
+          } | tee artifacts/orin/env.txt
+
+      - name: Upload ORIN diagnostics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: orin-runner-env
+          path: artifacts/orin/env.txt
+          if-no-files-found: error

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -8,6 +8,12 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
 - Runner: ORIN self-hosted GitHub Actions runner (LAN-local)
 - Deploy dir: `/opt/healthdelta`
 
+## Runner diagnostics proof workflow
+- Workflow: `.github/workflows/orin_runner_diagnostics.yml`
+- Trigger: manual dispatch
+- Purpose: prove runner scheduling + capture host environment evidence without deploying.
+- Expected artifact: `orin-runner-env` containing `env.txt` (uname/arch/docker/docker compose versions).
+
 ## ORIN prerequisites
 1) GitHub Actions self-hosted runner installed on ORIN
    - Labels must include: `self-hosted`, `linux`, `orin` (matches workflow `runs-on`)
@@ -49,4 +55,3 @@ The deploy workflow verifies:
 ## Credentials / secrets
 - The workflow uses `GITHUB_TOKEN` for `docker login ghcr.io` with `packages: read` permission.
 - If GHCR pulls fail on ORIN, use a fine-grained PAT with `read:packages` via a new secret and update the workflow accordingly (do not commit tokens).
-


### PR DESCRIPTION
Issue: #132

## What
- added ORIN diagnostics workflow `.github/workflows/orin_runner_diagnostics.yml`
- job runs on `self-hosted, linux, orin` and captures runner proof data
- logs and artifact include `uname -a`, `arch`, `docker --version`, `docker compose version`
- uploads deterministic artifact `orin-runner-env` (`artifacts/orin/env.txt`)
- updated `docs/runbook_orin_deploy.md` with diagnostics workflow usage
- added required `.ai` audit artifacts

## Validation
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- dispatch `ORIN Runner Diagnostics` workflow and verify artifact/logs

Closes #132
