### PR TITLE
Issue: #136 ORIN deploy proof artifacts + tagged verification

### DIFF
--- a/.ai/prompts/issue_136.md
+++ b/.ai/prompts/issue_136.md
@@ -1,0 +1,22 @@
+---
+Story
+As an operator,
+I want a reproducible GitHub->ORIN deployment proof using a real release tag,
+So that backend container deployment capability is demonstrated end-to-end with evidence artifacts.
+
+Context / Why
+After enabling runner diagnostics and multi-arch publish, the remaining cap is a full tagged release flowing through ORIN deploy verification with logs/artifacts.
+
+Acceptance Criteria
+- Given a new release tag, when Release workflow runs, then backend multi-arch image is published and inspect logs show `linux/amd64` and `linux/arm64`.
+- Given that tag, when Deploy Backend (ORIN) runs, then ORIN pulls/deploys the tagged image and backend verification passes (`/healthz`, `/version` version+sha match).
+- Deploy workflow uploads deterministic artifacts containing deploy and verify logs.
+- Issue closure references run URLs for diagnostics, release, and deploy proof.
+
+Out of Scope
+- Feature-level backend changes.
+- New governance policy requirements.
+
+Notes
+- If ORIN runner/host prerequisites are unavailable, preserve repo-side fixes and document exact host remediation required.
+---

--- a/.ai/sessions/2026-02-01/session_17.md
+++ b/.ai/sessions/2026-02-01/session_17.md
@@ -1,0 +1,15 @@
+# Session 17 - 2026-02-01
+
+Issue: #136
+
+Goal
+- Close GitHub->ORIN deployment proof with deterministic deploy artifacts on a tagged release.
+
+Notes
+- Updated `.github/workflows/deploy_backend_orin.yml` to upload `orin-deploy-proof` artifacts.
+- Added deploy metadata capture (`tag`, `version`, `sha`, run URL).
+- Added workflow timeout guard (`timeout-minutes: 30`) for bounded deploy attempts.
+- Updated `docs/runbook_orin_deploy.md` to document deploy-proof artifacts.
+
+Local verification
+- GitHub Actions workflow validation on PR

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -80,3 +80,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,130,,55,codex,,"Governance hardening for rewrite-tolerant non-blocking enforcement"
 2026-02-01,132,UNASSIGNED,25,codex,UNASSIGNED,"ORIN runner diagnostics workflow + evidence artifact"
 2026-02-01,134,UNASSIGNED,35,codex,UNASSIGNED,"Release workflow multi-arch backend publish + manifest verification"
+2026-02-01,136,UNASSIGNED,45,codex,UNASSIGNED,"ORIN deploy workflow proof artifacts + tagged release/deploy execution"

--- a/.github/workflows/deploy_backend_orin.yml
+++ b/.github/workflows/deploy_backend_orin.yml
@@ -19,6 +19,7 @@ jobs:
   deploy:
     name: ORIN deploy + verify
     runs-on: [self-hosted, linux, orin]
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: read
@@ -50,7 +51,29 @@ jobs:
       - name: Deploy + verify (compose)
         run: |
           set -euo pipefail
+          mkdir -p artifacts/orin-deploy
           TAG="${{ steps.v.outputs.tag }}" VERSION="${{ steps.v.outputs.ver }}" GIT_SHA="${{ steps.v.outputs.sha }}" \
             DEPLOY_DIR="/opt/healthdelta" SERVICE_NAME="backend" BASE_URL="http://127.0.0.1:8080" \
-            bash scripts/cd/orin_deploy_backend.sh
+            bash scripts/cd/orin_deploy_backend.sh | tee artifacts/orin-deploy/deploy_verify.log
 
+      - name: Record deploy metadata
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/orin-deploy
+          {
+            echo "tag=${{ steps.v.outputs.tag }}"
+            echo "version=${{ steps.v.outputs.ver }}"
+            echo "git_sha=${{ steps.v.outputs.sha }}"
+            echo "run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > artifacts/orin-deploy/metadata.txt
+
+      - name: Upload ORIN deploy artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: orin-deploy-proof
+          path: |
+            artifacts/orin-deploy/deploy_verify.log
+            artifacts/orin-deploy/metadata.txt
+          if-no-files-found: error

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -39,6 +39,9 @@ The deploy workflow verifies:
 - `GET /healthz` returns 200
 - `GET /version` returns `version=X.Y.Z` and `git_sha=<sha>`
 - Recent logs do not contain obvious fatal indicators (bounded tail scan)
+- Workflow uploads artifact `orin-deploy-proof` containing:
+  - `deploy_verify.log`
+  - `metadata.txt` (tag/version/sha/run URL)
 
 ## Rollback
 1) Choose a previous tag (example: `v0.0.1`)


### PR DESCRIPTION
Issue: #136

## What
- updated ORIN deploy workflow to emit deterministic proof artifacts (`orin-deploy-proof`)
- capture deploy/verify command output to `artifacts/orin-deploy/deploy_verify.log`
- record deploy metadata (`tag`, `version`, `git_sha`, run URL) to `artifacts/orin-deploy/metadata.txt`
- added `timeout-minutes: 30` to bound deploy attempts
- updated ORIN deploy runbook with artifact expectations
- added required `.ai` audit artifacts

## Validation
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- tagged release run + ORIN deploy run URLs and artifacts recorded on issue closure

Closes #136
