### PR TITLE
Issue: #138 Option A ORIN deploy hardening (no sudo)

### DIFF
--- a/.ai/prompts/issue_138.md
+++ b/.ai/prompts/issue_138.md
@@ -1,0 +1,22 @@
+---
+Story
+As a maintainer,
+I want ORIN deploy automation to run without sudo,
+So that deployment does not hang on non-interactive password prompts.
+
+Context / Why
+The ORIN deploy script currently attempts `sudo mkdir`/`sudo chown` when the deploy directory is missing. On self-hosted runner hosts this can block indefinitely waiting for a password. We already use a one-time directory bootstrap process, so deploy should fail fast with a clear remediation message instead of invoking sudo.
+
+Acceptance Criteria
+- Given `/opt/healthdelta` exists and is writable by the runner user, when ORIN deploy runs, then no sudo commands are executed.
+- Given `/opt/healthdelta` is missing, when ORIN deploy runs, then the script exits quickly with a clear one-time setup instruction.
+- Runbook docs state the deploy directory must be pre-created/chowned and that deploy workflow does not use sudo.
+- CI remains green for the repository checks.
+
+Out of Scope
+- Changing ORIN host sudoers policy.
+- Feature changes to backend service behavior.
+
+Notes
+- This is Option A: pre-create/chown deploy dir once, then run deploy without sudo.
+---

--- a/.ai/sessions/2026-02-01/session_18.md
+++ b/.ai/sessions/2026-02-01/session_18.md
@@ -1,0 +1,14 @@
+# Session 18 - 2026-02-01
+
+Issue: #138
+
+Goal
+- Implement Option A for ORIN deploy: no sudo in workflow path; fail fast with clear one-time bootstrap instructions.
+
+Notes
+- Removed sudo-based directory creation/ownership from `scripts/cd/orin_deploy_backend.sh`.
+- Added explicit missing-directory and non-writable-directory error messages with exact remediation commands.
+- Updated `docs/runbook_orin_deploy.md` to require one-time `/opt/healthdelta` bootstrap and clarify no sudo during deploy workflow runs.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -81,3 +81,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,132,UNASSIGNED,25,codex,UNASSIGNED,"ORIN runner diagnostics workflow + evidence artifact"
 2026-02-01,134,UNASSIGNED,35,codex,UNASSIGNED,"Release workflow multi-arch backend publish + manifest verification"
 2026-02-01,136,UNASSIGNED,45,codex,UNASSIGNED,"ORIN deploy workflow proof artifacts + tagged release/deploy execution"
+2026-02-01,138,UNASSIGNED,20,codex,UNASSIGNED,"Option A hardening: remove sudo from ORIN deploy path"

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -23,9 +23,10 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
    - `curl`
    - `python3`
 4) Deploy directory permissions
-   - Preferred: allow the runner user to write `/opt/healthdelta`:
+   - Required one-time bootstrap (no sudo during workflow execution):
      - `sudo mkdir -p /opt/healthdelta`
      - `sudo chown <runner-user>:<runner-user> /opt/healthdelta`
+   - The deploy workflow does not use sudo; it fails fast if the directory is missing/not writable.
    - The deploy workflow copies `deploy/orin/compose.yaml` and writes `/opt/healthdelta/.env` to pin the tag.
 
 ## What gets deployed

--- a/scripts/cd/orin_deploy_backend.sh
+++ b/scripts/cd/orin_deploy_backend.sh
@@ -12,13 +12,16 @@ VERSION="${VERSION:?expected version (e.g., 0.0.2)}"
 GIT_SHA="${GIT_SHA:?expected git sha}"
 
 if [ ! -d "$DEPLOY_DIR" ]; then
-  if command -v sudo >/dev/null 2>&1; then
-    sudo mkdir -p "$DEPLOY_DIR"
-    sudo chown "$USER":"$USER" "$DEPLOY_DIR"
-  else
-    echo "ERROR: deploy dir '$DEPLOY_DIR' does not exist and sudo is unavailable" >&2
-    exit 2
-  fi
+  echo "ERROR: deploy dir '$DEPLOY_DIR' is missing." >&2
+  echo "Create it once before deploy (Option A):" >&2
+  echo "  sudo mkdir -p $DEPLOY_DIR && sudo chown <runner-user>:<runner-user> $DEPLOY_DIR" >&2
+  exit 2
+fi
+
+if [ ! -w "$DEPLOY_DIR" ]; then
+  echo "ERROR: deploy dir '$DEPLOY_DIR' is not writable by user '$(id -un)'." >&2
+  echo "Fix ownership once: sudo chown <runner-user>:<runner-user> $DEPLOY_DIR" >&2
+  exit 2
 fi
 
 cp "$REPO_ROOT/deploy/orin/compose.yaml" "$DEPLOY_DIR/compose.yaml"
@@ -34,4 +37,3 @@ docker compose --env-file .env up -d --remove-orphans
 DEPLOY_DIR="$DEPLOY_DIR" SERVICE_NAME="$SERVICE_NAME" BASE_URL="$BASE_URL" \
   EXPECTED_TAG="$TAG" EXPECTED_VERSION="$VERSION" EXPECTED_SHA="$GIT_SHA" \
   "$REPO_ROOT/scripts/cd/orin_verify_backend.sh"
-


### PR DESCRIPTION
Issue: #138

## What
- removed sudo usage from `scripts/cd/orin_deploy_backend.sh`
- deploy now fails fast with clear one-time setup instructions if `/opt/healthdelta` is missing
- deploy now fails fast if `/opt/healthdelta` is not writable by runner user
- updated `docs/runbook_orin_deploy.md` to codify Option A (pre-create/chown once, no sudo during deploy)
- added required `.ai` audit artifacts

## Validation
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`

Closes #138
