### PR TITLE
Issue: #140 fix ORIN verify script permission failure

### DIFF
--- a/.ai/prompts/issue_140.md
+++ b/.ai/prompts/issue_140.md
@@ -1,0 +1,21 @@
+---
+Story
+As an operator,
+I want ORIN deploy verification to run reliably regardless execute-bit state,
+So that deploy proof does not fail with shell permission errors.
+
+Context / Why
+Manual ORIN deploy proof run failed with exit 126 because `scripts/cd/orin_verify_backend.sh` was invoked directly and not executable on the runner checkout. This is a tooling-path failure, not a deployment logic failure.
+
+Acceptance Criteria
+- ORIN deploy workflow no longer fails with `Permission denied` when running verify script.
+- Deploy script invokes verify via `bash` to avoid dependence on file execute bit.
+- A rerun of Deploy Backend (ORIN) with tag `v0.0.3` completes `Deploy + verify (compose)` successfully.
+
+Out of Scope
+- Changing backend application behavior.
+- New governance requirements.
+
+Notes
+- Keep scope to command invocation hardening only.
+---

--- a/.ai/sessions/2026-02-01/session_19.md
+++ b/.ai/sessions/2026-02-01/session_19.md
@@ -1,0 +1,13 @@
+# Session 19 - 2026-02-01
+
+Issue: #140
+
+Goal
+- Fix ORIN deploy verify invocation to avoid exit 126 permission failures.
+
+Notes
+- Updated `scripts/cd/orin_deploy_backend.sh` to run `orin_verify_backend.sh` via `bash`.
+- This removes dependency on execute-bit state in runner checkout while preserving verification behavior.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -82,3 +82,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,134,UNASSIGNED,35,codex,UNASSIGNED,"Release workflow multi-arch backend publish + manifest verification"
 2026-02-01,136,UNASSIGNED,45,codex,UNASSIGNED,"ORIN deploy workflow proof artifacts + tagged release/deploy execution"
 2026-02-01,138,UNASSIGNED,20,codex,UNASSIGNED,"Option A hardening: remove sudo from ORIN deploy path"
+2026-02-01,140,UNASSIGNED,15,codex,UNASSIGNED,"ORIN deploy verify invocation fix for non-executable script path"

--- a/scripts/cd/orin_deploy_backend.sh
+++ b/scripts/cd/orin_deploy_backend.sh
@@ -36,4 +36,4 @@ docker compose --env-file .env up -d --remove-orphans
 
 DEPLOY_DIR="$DEPLOY_DIR" SERVICE_NAME="$SERVICE_NAME" BASE_URL="$BASE_URL" \
   EXPECTED_TAG="$TAG" EXPECTED_VERSION="$VERSION" EXPECTED_SHA="$GIT_SHA" \
-  "$REPO_ROOT/scripts/cd/orin_verify_backend.sh"
+  bash "$REPO_ROOT/scripts/cd/orin_verify_backend.sh"


### PR DESCRIPTION
Issue: #140

## What
- fixed `scripts/cd/orin_deploy_backend.sh` to invoke verify script via `bash`
- removes dependency on executable bit for `scripts/cd/orin_verify_backend.sh`
- preserves deploy verification logic while preventing exit 126 permission failures
- added required `.ai` audit artifacts

## Validation
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- rerun `Deploy Backend (ORIN)` workflow_dispatch with `tag=v0.0.3`

Closes #140
