### PR TITLE
Issue: #143 harden auto tag deploy against GHCR publish race

### DIFF
--- a/.ai/prompts/issue_143.md
+++ b/.ai/prompts/issue_143.md
@@ -1,0 +1,21 @@
+---
+Story
+As an operator,
+I want ORIN tag-triggered deploy to wait for image availability,
+So that deploy does not fail when release image publish and deploy workflows start concurrently.
+
+Context / Why
+On tag v0.0.4, Deploy Backend (ORIN) started before GHCR tag was visible and failed with `manifest unknown`. The deploy workflow should handle publish latency by polling for tag availability before compose pull.
+
+Acceptance Criteria
+- Given tag-triggered deploy, when GHCR image publish lags briefly, then deploy waits/polls until the tag is available (bounded timeout) instead of failing immediately.
+- Workflow logs clearly show wait attempts and timeout behavior.
+- Automatic tag-triggered deploy succeeds after release publish in normal conditions.
+
+Out of Scope
+- Changing release tagging strategy.
+- Backend feature changes.
+
+Notes
+- Keep polling bounded and deterministic.
+---

--- a/.ai/sessions/2026-02-01/session_20.md
+++ b/.ai/sessions/2026-02-01/session_20.md
@@ -1,0 +1,14 @@
+# Session 20 - 2026-02-01
+
+Issue: #143
+
+Goal
+- Make auto tag-triggered ORIN deploy resilient to GHCR publish latency.
+
+Notes
+- Added a bounded wait loop in `.github/workflows/deploy_backend_orin.yml` to poll GHCR manifest availability before deploy.
+- Added clear progress and timeout logging for image availability checks.
+- Updated `docs/runbook_orin_deploy.md` to include the manifest-availability gate in verification behavior.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -83,3 +83,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,136,UNASSIGNED,45,codex,UNASSIGNED,"ORIN deploy workflow proof artifacts + tagged release/deploy execution"
 2026-02-01,138,UNASSIGNED,20,codex,UNASSIGNED,"Option A hardening: remove sudo from ORIN deploy path"
 2026-02-01,140,UNASSIGNED,15,codex,UNASSIGNED,"ORIN deploy verify invocation fix for non-executable script path"
+2026-02-01,143,UNASSIGNED,20,codex,UNASSIGNED,"ORIN deploy waits for GHCR manifest availability on tag-triggered runs"

--- a/.github/workflows/deploy_backend_orin.yml
+++ b/.github/workflows/deploy_backend_orin.yml
@@ -48,6 +48,27 @@ jobs:
           echo "ver=$ver" >> "$GITHUB_OUTPUT"
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
+      - name: Wait for GHCR tag availability
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${{ github.repository_owner }}/healthdelta-backend:${{ steps.v.outputs.tag }}"
+          max_attempts=45
+          delay_seconds=4
+          attempt=1
+          while [ "$attempt" -le "$max_attempts" ]; do
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              echo "image available: $image"
+              break
+            fi
+            echo "waiting for image manifest ($attempt/$max_attempts): $image"
+            attempt=$((attempt + 1))
+            sleep "$delay_seconds"
+          done
+          if [ "$attempt" -gt "$max_attempts" ]; then
+            echo "ERROR: timed out waiting for image manifest: $image"
+            exit 1
+          fi
+
       - name: Deploy + verify (compose)
         run: |
           set -euo pipefail

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -36,6 +36,7 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
 
 ## Verification (“150%” backend checks)
 The deploy workflow verifies:
+- GHCR tag manifest is available before compose pull (bounded wait loop).
 - Correct image tag is running (container image contains `:vX.Y.Z`)
 - `GET /healthz` returns 200
 - `GET /version` returns `version=X.Y.Z` and `git_sha=<sha>`


### PR DESCRIPTION
Issue: #143

## What
- hardened `.github/workflows/deploy_backend_orin.yml` with bounded GHCR manifest wait loop before deploy
- prevents immediate `manifest unknown` failures when deploy workflow races image publish on fresh tags
- added explicit wait/progress/timeout logging
- updated `docs/runbook_orin_deploy.md` to document the manifest availability gate
- added required `.ai` audit artifacts

## Validation
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- push a fresh tag and verify auto-triggered ORIN deploy succeeds

Closes #143
