### PR TITLE
Issue: #122 ORIN model/runtime matrix for local inference

### DIFF
--- a/.ai/prompts/issue_122.md
+++ b/.ai/prompts/issue_122.md
@@ -1,0 +1,22 @@
+---
+Story
+As a maintainer,
+I want a Jetson Orin model/runtime decision matrix,
+So that local-only inference is feasible within device memory/latency constraints.
+
+Context / Why
+Orin deployment needs explicit tradeoff decisions (accuracy, latency, memory, GPU use) for summaries and risk flags first, then trends/Q&A. Without a matrix, implementation can stall or select incompatible models.
+
+Acceptance Criteria
+- Given Orin Nano Super constraints, when planning is completed, then a ranked model/runtime matrix is documented (primary + fallback CPU path).
+- Given target workloads (summary, risk flags, trend, Q&A), when sizing is documented, then expected latency/memory envelopes are specified per workload.
+- Given local-only/privacy constraints, when architecture notes are produced, then no cloud dependencies are included.
+- Given CI evidence requirements, when this issue is merged, then planning artifacts are persisted and referenced from docs.
+
+Out of Scope
+- Model benchmarking implementation.
+- Runtime optimization code.
+
+Notes
+- Prefer quantized, ARM64-compatible options with CUDA/TensorRT compatibility where practical.
+---

--- a/.ai/sessions/2026-02-02/session_2.md
+++ b/.ai/sessions/2026-02-02/session_2.md
@@ -1,0 +1,13 @@
+# Session 2 - 2026-02-02
+
+Issue: #122
+
+Goal
+- Produce a durable ORIN local model/runtime decision matrix with workload envelopes and fallback paths.
+
+Notes
+- Added `docs/orin_model_runtime_matrix.md` with ranked runtime choices, workload-by-workload latency/memory envelopes, and local-only architecture constraints.
+- Linked the matrix from `docs/runbook_orin_deploy.md` and refreshed `docs/plan.md` status notes for #121/#122.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -85,3 +85,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,140,UNASSIGNED,15,codex,UNASSIGNED,"ORIN deploy verify invocation fix for non-executable script path"
 2026-02-01,143,UNASSIGNED,20,codex,UNASSIGNED,"ORIN deploy waits for GHCR manifest availability on tag-triggered runs"
 2026-02-02,121,UNASSIGNED,45,codex,UNASSIGNED,"Export profile schema inventory + sensitive field map + CI artifact evidence"
+2026-02-02,122,UNASSIGNED,35,codex,UNASSIGNED,"ORIN local model/runtime matrix planning artifact + docs linkage"

--- a/docs/orin_model_runtime_matrix.md
+++ b/docs/orin_model_runtime_matrix.md
@@ -1,0 +1,50 @@
+# ORIN local model/runtime matrix (Issue #122)
+
+This planning artifact ranks local-only runtime options for `orin.local` and sets workload envelopes for backend implementation.
+
+Issue: #122
+
+## Constraints (authoritative for this phase)
+- Target host: Jetson Orin (ARM64 Linux, CUDA-capable GPU, shared memory budget).
+- Privacy: local-only inference; no cloud model calls, no third-party hosted embeddings.
+- Reliability: deterministic fallback must exist when GPU runtime is unavailable.
+- Deployment compatibility: artifacts must remain ARM64-compatible and container-friendly.
+
+## Ranked runtime options
+
+1) `llama.cpp` (ARM64 build, CUDA/cuBLAS enabled when available)
+   - Why first: mature quantized GGUF support, strong ARM64 portability, same runtime can run GPU or CPU fallback.
+   - Primary use: summaries, risk flags, trend narrative generation, grounded Q&A response synthesis.
+
+2) ONNX Runtime + TensorRT EP (selective model path)
+   - Why second: useful for smaller classification-style models when we need predictable latency.
+   - Primary use: optional risk-flag scoring model path (non-generative) if later benchmarking justifies complexity.
+
+3) TensorRT-LLM (deferred)
+   - Why third: potentially best throughput but highest operational complexity for current scope.
+   - Primary use: future optimization track after MMF behavior is proven with simpler runtime.
+
+## Workload matrix (ranked primary + CPU fallback)
+
+| Workload | Primary runtime/model plan | CPU fallback plan | Target latency envelope | Memory envelope (planning) |
+|---|---|---|---|---|
+| Doctor-style summary | `llama.cpp` + 3B instruct GGUF (Q4/Q5) | same model/runtime CPU-only | p50 <= 3s, p95 <= 8s per request | GPU path <= 6 GiB total, CPU path <= 8 GiB RSS |
+| Risk flags v1 (rule + explanation) | Rules engine + `llama.cpp` 3B for rationale text | rules-only output + optional short CPU rationale | rules <= 1s, full response p95 <= 5s | <= 4 GiB for explanation path |
+| Trend analysis v1 | `llama.cpp` 3B/7B quantized (bounded context) | 3B CPU-only with reduced context | p50 <= 5s, p95 <= 12s | <= 7 GiB (GPU), <= 8 GiB (CPU) |
+| Grounded Q&A v1 (abstain-capable) | retrieval + `llama.cpp` 3B synthesis | retrieval + template/rules abstain response | retrieval <= 1.5s, full p95 <= 8s | <= 6 GiB with retrieval cache |
+
+## Local-only architecture notes
+- Retrieval/indexing stays local (DuckDB + local text index path); no external vector DB SaaS.
+- Prompt orchestration stays in backend service containers on ORIN.
+- Model assets are versioned as local deploy dependencies and referenced by release-tagged backend deployments.
+- Fallback mode is explicit: if GPU path is unavailable, service remains operable in degraded CPU mode.
+
+## Decision for MMF implementation sequence
+- Implement with `llama.cpp` as the single mandatory runtime for Issues #123-#126.
+- Keep ONNX/TensorRT as optional optimization tasks only after MMF acceptance criteria pass.
+- Preserve one code path for prompt/guardrail logic so runtime swaps do not change behavior contracts.
+
+## Validation hooks for downstream issues
+- Each workload issue must publish p50/p95 latency and memory observations against this matrix.
+- CI/deploy artifacts must record runtime mode (`gpu` or `cpu-fallback`) and model id/hash.
+- Any deviation from envelopes requires issue-level note and explicit follow-up issue.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -55,9 +55,9 @@ Active governance carryover
 New planning phase: Orin production deployment target (`orin.local`)
 3) Issue #120 - Planning: Orin production deployment MMF backlog
    - https://github.com/dave0875/HealthDelta/issues/120
-4) Issue #121 - Orin MMF: export inventory + PHI field map
+4) Issue #121 - Orin MMF: export inventory + PHI field map (closed)
    - https://github.com/dave0875/HealthDelta/issues/121
-5) Issue #122 - Orin MMF: local model/runtime matrix for summaries + risk flags
+5) Issue #122 - Orin MMF: local model/runtime matrix for summaries + risk flags (active)
    - https://github.com/dave0875/HealthDelta/issues/122
 6) Issue #123 - Orin MMF: ingest-to-summary vertical slice on backend
    - https://github.com/dave0875/HealthDelta/issues/123

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -8,6 +8,10 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
 - Runner: ORIN self-hosted GitHub Actions runner (LAN-local)
 - Deploy dir: `/opt/healthdelta`
 
+## Planning artifact linkage
+- Model/runtime planning matrix for ORIN MMF workloads: `docs/orin_model_runtime_matrix.md` (Issue #122).
+- This matrix is the source for summary/risk/trend/Q&A runtime selection and latency/memory envelopes.
+
 ## Runner diagnostics proof workflow
 - Workflow: `.github/workflows/orin_runner_diagnostics.yml`
 - Trigger: manual dispatch


### PR DESCRIPTION
Issue: #122

## What
- add `docs/orin_model_runtime_matrix.md` as the ranked ORIN runtime decision matrix
- define workload-by-workload primary runtime and CPU fallback for summary, risk flags, trend analysis, and grounded Q&A
- specify planning latency/memory envelopes per workload
- document explicit local-only/privacy architecture constraints (no cloud model dependencies)
- link the planning artifact from `docs/runbook_orin_deploy.md` and refresh status in `docs/plan.md`
- add required `.ai/` prompt/session/time audit artifacts for this issue

## Why
Issue #122 requires a durable model/runtime decision baseline before implementing MMF backend features on ORIN.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #122
