### PR TITLE
Issue: #123 ingest-to-summary backend vertical slice

### DIFF
--- a/.ai/prompts/issue_123.md
+++ b/.ai/prompts/issue_123.md
@@ -1,0 +1,22 @@
+---
+Story
+As an operator,
+I want a first end-to-end Orin vertical slice (ingest -> de-id -> summary API),
+So that production readiness can be proven with a minimal user-visible outcome.
+
+Context / Why
+A vertical slice de-risks architecture by proving the full chain on target hardware, not just isolated components.
+
+Acceptance Criteria
+- Given a synthetic fixture set, when the slice runs on Orin, then a share-safe summary response is produced through backend API.
+- Given de-id policy, when summary generation executes, then banned PHI tokens are absent from logs and outputs.
+- Given traceability requirements, when summary output is returned, then source references/citations to ingested records are included.
+- Given deployment proof needs, when CI for this slice runs, then artifacts include run logs and output samples.
+
+Out of Scope
+- Risk scoring logic.
+- Trend and Q&A features.
+
+Notes
+- Keep scope minimal and deterministic.
+---

--- a/.ai/sessions/2026-02-02/session_3.md
+++ b/.ai/sessions/2026-02-02/session_3.md
@@ -1,0 +1,17 @@
+# Session 3 - 2026-02-02
+
+Issue: #123
+
+Goal
+- Deliver the first backend vertical slice endpoint (ingest -> de-id -> summary API) with citation and CI evidence artifacts.
+
+Notes
+- Added `POST /summary` to backend server with deterministic vertical-slice orchestration and PHI token guard checks.
+- Added backend smoke runner script for CI evidence capture.
+- Extended Linux CI artifacts with vertical-slice logs and summary output sample.
+- Updated ORIN deploy runbook and plan status to reference vertical-slice behavior.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_backend_server.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -86,3 +86,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-01,143,UNASSIGNED,20,codex,UNASSIGNED,"ORIN deploy waits for GHCR manifest availability on tag-triggered runs"
 2026-02-02,121,UNASSIGNED,45,codex,UNASSIGNED,"Export profile schema inventory + sensitive field map + CI artifact evidence"
 2026-02-02,122,UNASSIGNED,35,codex,UNASSIGNED,"ORIN local model/runtime matrix planning artifact + docs linkage"
+2026-02-02,123,UNASSIGNED,70,codex,UNASSIGNED,"Backend ingest->de-id->summary vertical slice API with citation and CI evidence artifacts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,16 @@ jobs:
             --sample-json 3 \
             --top-files 5 > artifacts/linux/profile_smoke.log 2>&1
 
+      - name: Run backend vertical-slice smoke (artifact evidence)
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/linux/backend_slice
+          python3 scripts/backend_slice_smoke.py \
+            --input tests/fixtures/profile_export \
+            --work artifacts/linux/backend_slice/work \
+            --response artifacts/linux/backend_slice/summary_response.json \
+            --log artifacts/linux/backend_slice/smoke.log
+
       - name: Upload Linux unittest artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -106,6 +116,8 @@ jobs:
             artifacts/linux/profile/profile.md
             artifacts/linux/profile/clinical_schema_keys.csv
             artifacts/linux/profile/sensitive_field_map.json
+            artifacts/linux/backend_slice/smoke.log
+            artifacts/linux/backend_slice/summary_response.json
           if-no-files-found: error
 
       - name: Fail if policy or unittest failed

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -57,9 +57,9 @@ New planning phase: Orin production deployment target (`orin.local`)
    - https://github.com/dave0875/HealthDelta/issues/120
 4) Issue #121 - Orin MMF: export inventory + PHI field map (closed)
    - https://github.com/dave0875/HealthDelta/issues/121
-5) Issue #122 - Orin MMF: local model/runtime matrix for summaries + risk flags (active)
+5) Issue #122 - Orin MMF: local model/runtime matrix for summaries + risk flags (closed)
    - https://github.com/dave0875/HealthDelta/issues/122
-6) Issue #123 - Orin MMF: ingest-to-summary vertical slice on backend
+6) Issue #123 - Orin MMF: ingest-to-summary vertical slice on backend (active)
    - https://github.com/dave0875/HealthDelta/issues/123
 7) Issue #124 - Orin MMF: risk flags v1 with evidence + disclaimers
    - https://github.com/dave0875/HealthDelta/issues/124

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -38,6 +38,19 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
 - Pinned tag file: `/opt/healthdelta/.env` with `HEALTHDELTA_BACKEND_IMAGE_TAG=vX.Y.Z`
 - Service listens on `http://127.0.0.1:8080` (port mapping `8080:8080`)
 
+## Vertical slice endpoint (Issue #123)
+- Endpoint: `POST /summary`
+- Purpose: run a minimal ingest -> identity -> de-id -> NDJSON vertical slice and return a share-safe summary response.
+- Required request fields:
+  - `input_path`: local path to a synthetic/unpacked export fixture
+- Optional request fields:
+  - `work_dir`: scratch output root (default `data/backend_slice`)
+  - `citation_limit`: max response citations (default 12, capped at 50)
+- Response includes:
+  - deterministic stream-count summary text
+  - citation list (`stream`, `record_key`, `source_file`, `event_time`, `line`)
+  - PHI token guard check result (`phi_tokens_checked`, `phi_token_hits`)
+
 ## Verification (“150%” backend checks)
 The deploy workflow verifies:
 - GHCR tag manifest is available before compose pull (bounded wait loop).
@@ -48,6 +61,9 @@ The deploy workflow verifies:
 - Workflow uploads artifact `orin-deploy-proof` containing:
   - `deploy_verify.log`
   - `metadata.txt` (tag/version/sha/run URL)
+- CI Linux job also uploads backend slice evidence artifacts:
+  - `artifacts/linux/backend_slice/smoke.log`
+  - `artifacts/linux/backend_slice/summary_response.json`
 
 ## Rollback
 1) Choose a previous tag (example: `v0.0.1`)

--- a/healthdelta/backend_server.py
+++ b/healthdelta/backend_server.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from typing import Any
 
+from healthdelta.deid import deidentify_run
+from healthdelta.identity import build_identity
+from healthdelta.ingest import ingest_to_staging
+from healthdelta.ndjson_export import export_ndjson
 from healthdelta.version import get_build_info
 
 
@@ -18,6 +25,137 @@ def version_payload() -> dict[str, Any]:
     return {
         "version": info.get("version"),
         "git_sha": info.get("git_sha"),
+    }
+
+
+def _read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_identity_tokens(identity_dir: Path) -> set[str]:
+    people_path = identity_dir / "people.json"
+    if not people_path.exists():
+        return set()
+    obj = _read_json(people_path)
+    people = obj.get("people") if isinstance(obj, dict) else None
+    if not isinstance(people, list):
+        return set()
+    out: set[str] = set()
+    for row in people:
+        if not isinstance(row, dict):
+            continue
+        first = row.get("first_norm")
+        last = row.get("last_norm")
+        if isinstance(first, str) and first.strip():
+            out.add(first.strip().lower())
+        if isinstance(last, str) and last.strip():
+            out.add(last.strip().lower())
+    return out
+
+
+def _find_token_hits(text: str, tokens: set[str]) -> list[str]:
+    hits: list[str] = []
+    for token in sorted(tokens):
+        if not token:
+            continue
+        pat = re.compile(rf"\b{re.escape(token)}\b", re.IGNORECASE)
+        if pat.search(text):
+            hits.append(token)
+    return hits
+
+
+def _build_summary_from_ndjson(ndjson_dir: Path, *, citation_limit: int) -> tuple[str, list[dict[str, Any]], dict[str, int]]:
+    counts: dict[str, int] = {}
+    citations: list[dict[str, Any]] = []
+    per_stream: dict[str, int] = {}
+    total = 0
+
+    for path in sorted(ndjson_dir.glob("*.ndjson"), key=lambda p: p.name):
+        stream = path.stem
+        stream_count = 0
+        with path.open("r", encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                stream_count += 1
+                total += 1
+                if len(citations) < citation_limit and per_stream.get(stream, 0) < 3:
+                    citations.append(
+                        {
+                            "stream": stream,
+                            "line": line_no,
+                            "record_key": row.get("record_key"),
+                            "source_file": row.get("source_file"),
+                            "event_time": row.get("event_time"),
+                        }
+                    )
+                    per_stream[stream] = per_stream.get(stream, 0) + 1
+        if stream_count:
+            counts[stream] = stream_count
+
+    lines = ["HealthDelta Vertical Slice Summary", f"total_records={total}"]
+    for stream, n in sorted(counts.items(), key=lambda kv: kv[0]):
+        lines.append(f"records.{stream}={n}")
+    lines.append("Share-safe mode enforced (de-id -> NDJSON).")
+    return "\n".join(lines) + "\n", citations, counts
+
+
+def _run_vertical_slice(*, input_path: str, work_dir: str, citation_limit: int = 12) -> dict[str, Any]:
+    input_p = Path(input_path)
+    if not input_p.exists():
+        raise FileNotFoundError(f"input path not found: {input_p}")
+
+    base = Path(work_dir)
+    run_suffix = time.strftime("%Y%m%d%H%M%S", time.gmtime())
+    run_id = f"slice-{run_suffix}"
+    run_root = base / run_id
+    staging_root = run_root / "staging"
+    identity_dir = run_root / "state" / "identity"
+    deid_dir = run_root / "deid"
+    ndjson_dir = run_root / "ndjson"
+    log_path = run_root / "slice.log"
+
+    run_root.mkdir(parents=True, exist_ok=True)
+    log_lines: list[str] = [f"run_id={run_id}"]
+
+    staged = ingest_to_staging(input_path=str(input_p), staging_root=str(staging_root), run_id_override=run_id)
+    log_lines.append("step=ingest_to_staging status=ok")
+    build_identity(staging_run_dir=str(staged), output_dir=str(identity_dir))
+    log_lines.append("step=identity_build status=ok")
+    deidentify_run(staging_run_dir=str(staged), identity_dir=str(identity_dir), out_dir=str(deid_dir))
+    log_lines.append("step=deidentify_run status=ok")
+    export_ndjson(input_dir=str(deid_dir), out_dir=str(ndjson_dir), mode="share")
+    log_lines.append("step=export_ndjson status=ok")
+
+    summary, citations, counts = _build_summary_from_ndjson(ndjson_dir, citation_limit=citation_limit)
+    tokens = _load_identity_tokens(identity_dir)
+    scan_text = "\n".join([summary, json.dumps(citations, sort_keys=True), "\n".join(log_lines)])
+    hits = _find_token_hits(scan_text, tokens)
+    if hits:
+        raise RuntimeError(f"policy failure: banned PHI tokens detected in output/logs: {', '.join(sorted(hits))}")
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("\n".join(log_lines) + "\n", encoding="utf-8")
+
+    return {
+        "ok": True,
+        "run_id": run_id,
+        "summary": summary,
+        "counts_by_stream": [{"stream": k, "count": counts[k]} for k in sorted(counts.keys())],
+        "citations": citations,
+        "policy": {"phi_tokens_checked": sorted(tokens), "phi_token_hits": []},
+        "artifacts": {
+            "run_dir": run_id,
+            "slice_log": "slice.log",
+            "ndjson_dir": "ndjson",
+        },
     }
 
 
@@ -41,6 +179,45 @@ class _Handler(BaseHTTPRequestHandler):
             self._send_json(200, version_payload())
             return
         self._send_json(404, {"error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/summary":
+            self._send_json(404, {"error": "not_found"})
+            return
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._send_json(400, {"error": "invalid_content_length"})
+            return
+        raw = self.rfile.read(max(content_length, 0))
+        try:
+            payload = json.loads(raw.decode("utf-8")) if raw else {}
+        except Exception:
+            self._send_json(400, {"error": "invalid_json"})
+            return
+        if not isinstance(payload, dict):
+            self._send_json(400, {"error": "invalid_payload"})
+            return
+        input_path = payload.get("input_path")
+        if not isinstance(input_path, str) or not input_path.strip():
+            self._send_json(400, {"error": "input_path_required"})
+            return
+        work_dir = payload.get("work_dir")
+        if not isinstance(work_dir, str) or not work_dir.strip():
+            work_dir = "data/backend_slice"
+        citation_limit = payload.get("citation_limit")
+        if not isinstance(citation_limit, int) or citation_limit <= 0:
+            citation_limit = 12
+        citation_limit = min(citation_limit, 50)
+        try:
+            obj = _run_vertical_slice(input_path=input_path, work_dir=work_dir, citation_limit=citation_limit)
+        except FileNotFoundError as e:
+            self._send_json(400, {"error": "input_not_found", "detail": str(e)})
+            return
+        except Exception as e:
+            self._send_json(500, {"error": "summary_failed", "detail": str(e)})
+            return
+        self._send_json(200, obj)
 
 
 def make_server(*, host: str, port: int) -> ThreadingHTTPServer:
@@ -70,4 +247,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/healthdelta/progress.py
+++ b/healthdelta/progress.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import builtins
 import sys
 import time
 from dataclasses import dataclass
@@ -249,4 +250,6 @@ class Progress:
             pass
 
 
-progress = Progress()
+if not hasattr(builtins, "_healthdelta_progress_singleton"):
+    setattr(builtins, "_healthdelta_progress_singleton", Progress())
+progress = getattr(builtins, "_healthdelta_progress_singleton")

--- a/scripts/backend_slice_smoke.py
+++ b/scripts/backend_slice_smoke.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from healthdelta.backend_server import make_server
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Run backend /summary vertical-slice smoke request.")
+    p.add_argument("--input", required=True, help="Synthetic fixture input directory")
+    p.add_argument("--work", required=True, help="Working directory for slice outputs")
+    p.add_argument("--response", required=True, help="Output JSON response path")
+    p.add_argument("--log", required=True, help="Output smoke log path")
+    args = p.parse_args(argv)
+
+    server = make_server(host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(0.05)
+    host, port = server.server_address
+    base_url = f"http://{host}:{port}"
+
+    status = 0
+    detail = "ok"
+    response_obj: dict[str, object] = {}
+    try:
+        req_body = json.dumps(
+            {
+                "input_path": str(Path(args.input).resolve()),
+                "work_dir": str(Path(args.work).resolve()),
+                "citation_limit": 10,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        req = Request(base_url + "/summary", data=req_body, headers={"Content-Type": "application/json"}, method="POST")
+        with urlopen(req) as resp:
+            payload = resp.read().decode("utf-8")
+            response_obj = json.loads(payload)
+            if resp.status != 200:
+                status = 1
+                detail = f"unexpected status: {resp.status}"
+            elif not isinstance(response_obj.get("citations"), list) or not response_obj.get("citations"):
+                status = 1
+                detail = "missing citations"
+    except Exception as e:
+        status = 1
+        detail = str(e)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    _write(Path(args.response), json.dumps(response_obj, sort_keys=True, indent=2) + "\n")
+    log_text = "\n".join(
+        [
+            f"status={status}",
+            f"detail={detail}",
+            f"response_path={args.response}",
+            f"run_id={response_obj.get('run_id', '')}",
+        ]
+    )
+    _write(Path(args.log), log_text + "\n")
+    if status != 0:
+        print(log_text)
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backend_server.py
+++ b/tests/test_backend_server.py
@@ -1,8 +1,10 @@
 import json
+import tempfile
 import threading
 import time
 import unittest
-from urllib.request import urlopen
+from pathlib import Path
+from urllib.request import Request, urlopen
 
 
 class TestBackendServer(unittest.TestCase):
@@ -39,6 +41,49 @@ class TestBackendServer(unittest.TestCase):
                 obj = json.loads(resp.read().decode("utf-8"))
                 self.assertIn("version", obj)
                 self.assertIn("git_sha", obj)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_summary_vertical_slice(self) -> None:
+        server, thread, base_url = self._start_server()
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                payload = json.dumps(
+                    {
+                        "input_path": str((Path("tests/fixtures/profile_export")).resolve()),
+                        "work_dir": str((Path(td) / "work").resolve()),
+                        "citation_limit": 8,
+                    }
+                ).encode("utf-8")
+                req = Request(base_url + "/summary", data=payload, headers={"Content-Type": "application/json"}, method="POST")
+                with urlopen(req) as resp:
+                    self.assertEqual(resp.status, 200)
+                    obj = json.loads(resp.read().decode("utf-8"))
+                    self.assertTrue(obj.get("ok"))
+                    self.assertIn("summary", obj)
+                    self.assertIn("citations", obj)
+                    self.assertGreater(len(obj["citations"]), 0)
+                    blob = json.dumps(obj, sort_keys=True)
+                    self.assertNotIn("John", blob)
+                    self.assertNotIn("Doe", blob)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_summary_requires_input_path(self) -> None:
+        server, thread, base_url = self._start_server()
+        try:
+            payload = json.dumps({"work_dir": "tmp"}).encode("utf-8")
+            req = Request(base_url + "/summary", data=payload, headers={"Content-Type": "application/json"}, method="POST")
+            try:
+                urlopen(req)
+                self.fail("expected HTTP error")
+            except Exception as e:
+                body = getattr(e, "read", lambda: b"")().decode("utf-8")
+                self.assertIn("input_path_required", body)
         finally:
             server.shutdown()
             server.server_close()


### PR DESCRIPTION
Issue: #123

## What
- add backend `POST /summary` endpoint to run a deterministic vertical slice: ingest -> identity -> de-id -> NDJSON
- return share-safe summary text plus citation rows (`stream`, `record_key`, `source_file`, `event_time`, `line`)
- enforce PHI guardrail by scanning summary/citations/log text for identity-derived tokens before returning output
- add CI smoke runner `scripts/backend_slice_smoke.py` and upload vertical-slice logs + response artifacts
- add backend API tests for `/summary` success and request validation
- harden progress singleton lifecycle so progress tests remain stable when modules are imported before/after progress reload checks
- update ORIN deploy runbook + living plan status and add required `.ai/` audit artifacts for issue #123

## Why
Issue #123 requires a minimal user-visible backend outcome on target architecture that proves share-safe summary generation with citations and deterministic CI evidence.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_backend_server.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`
- `python3 scripts/backend_slice_smoke.py --input tests/fixtures/profile_export --work /tmp/hd-slice-work --response /tmp/hd-slice-response.json --log /tmp/hd-slice-smoke.log`

Closes #123
