### PR TITLE
Issue: #124 risk flags v1 with evidence and disclaimer

### DIFF
--- a/.ai/prompts/issue_124.md
+++ b/.ai/prompts/issue_124.md
@@ -1,0 +1,22 @@
+---
+Story
+As a user,
+I want clinically-oriented risk flags with transparent evidence,
+So that I can quickly identify records that need human follow-up.
+
+Context / Why
+Risk flags are highest priority in the super prompt. They must be information-only, auditable, and never framed as medical advice.
+
+Acceptance Criteria
+- Given canonical patient timelines, when risk-flag analysis runs, then outputs include deterministic flag categories and severities.
+- Given each emitted flag, when output is rendered, then evidence links to source records and rationale text are included.
+- Given safety constraints, when output is generated, then a clear non-medical-advice disclaimer is always present.
+- Given validation tests, when CI runs, then fixtures verify deterministic flag output and evidence traceability.
+
+Out of Scope
+- Automated treatment recommendations.
+- External clinician workflow integrations.
+
+Notes
+- Start with a constrained ruleset, then expand in follow-up issues.
+---

--- a/.ai/sessions/2026-02-02/session_4.md
+++ b/.ai/sessions/2026-02-02/session_4.md
@@ -1,0 +1,18 @@
+# Session 4 - 2026-02-02
+
+Issue: #124
+
+Goal
+- Add deterministic risk flags v1 with evidence traceability and mandatory non-medical-advice disclaimer.
+
+Notes
+- Added `healthdelta/risk_flags.py` with constrained deterministic rules and evidence projection from canonical NDJSON.
+- Extended backend `POST /summary` to return `risk_flags` including disclaimer and evidence rows.
+- Added deterministic unit tests for risk-flag output and backend response shape.
+- Updated ORIN deploy runbook + plan status markers.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_risk_flags.py -v
+- TZ=UTC python3 -m unittest tests/test_backend_server.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -87,3 +87,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,121,UNASSIGNED,45,codex,UNASSIGNED,"Export profile schema inventory + sensitive field map + CI artifact evidence"
 2026-02-02,122,UNASSIGNED,35,codex,UNASSIGNED,"ORIN local model/runtime matrix planning artifact + docs linkage"
 2026-02-02,123,UNASSIGNED,70,codex,UNASSIGNED,"Backend ingest->de-id->summary vertical slice API with citation and CI evidence artifacts"
+2026-02-02,124,UNASSIGNED,55,codex,UNASSIGNED,"Risk flags v1 deterministic ruleset with evidence traceability and disclaimer"

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -59,9 +59,9 @@ New planning phase: Orin production deployment target (`orin.local`)
    - https://github.com/dave0875/HealthDelta/issues/121
 5) Issue #122 - Orin MMF: local model/runtime matrix for summaries + risk flags (closed)
    - https://github.com/dave0875/HealthDelta/issues/122
-6) Issue #123 - Orin MMF: ingest-to-summary vertical slice on backend (active)
+6) Issue #123 - Orin MMF: ingest-to-summary vertical slice on backend (closed)
    - https://github.com/dave0875/HealthDelta/issues/123
-7) Issue #124 - Orin MMF: risk flags v1 with evidence + disclaimers
+7) Issue #124 - Orin MMF: risk flags v1 with evidence + disclaimers (active)
    - https://github.com/dave0875/HealthDelta/issues/124
 8) Issue #125 - Orin MMF: trend analysis v1 for longitudinal records
    - https://github.com/dave0875/HealthDelta/issues/125

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -49,6 +49,8 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
 - Response includes:
   - deterministic stream-count summary text
   - citation list (`stream`, `record_key`, `source_file`, `event_time`, `line`)
+  - deterministic risk flags (`flag_id`, `category`, `severity`, `rationale`, `evidence`)
+  - mandatory disclaimer string stating flags are not medical advice
   - PHI token guard check result (`phi_tokens_checked`, `phi_token_hits`)
 
 ## Verification (“150%” backend checks)

--- a/healthdelta/backend_server.py
+++ b/healthdelta/backend_server.py
@@ -13,6 +13,7 @@ from healthdelta.deid import deidentify_run
 from healthdelta.identity import build_identity
 from healthdelta.ingest import ingest_to_staging
 from healthdelta.ndjson_export import export_ndjson
+from healthdelta.risk_flags import build_risk_flags
 from healthdelta.version import get_build_info
 
 
@@ -135,8 +136,9 @@ def _run_vertical_slice(*, input_path: str, work_dir: str, citation_limit: int =
     log_lines.append("step=export_ndjson status=ok")
 
     summary, citations, counts = _build_summary_from_ndjson(ndjson_dir, citation_limit=citation_limit)
+    risk_flags = build_risk_flags(ndjson_dir=str(ndjson_dir))
     tokens = _load_identity_tokens(identity_dir)
-    scan_text = "\n".join([summary, json.dumps(citations, sort_keys=True), "\n".join(log_lines)])
+    scan_text = "\n".join([summary, json.dumps(citations, sort_keys=True), json.dumps(risk_flags, sort_keys=True), "\n".join(log_lines)])
     hits = _find_token_hits(scan_text, tokens)
     if hits:
         raise RuntimeError(f"policy failure: banned PHI tokens detected in output/logs: {', '.join(sorted(hits))}")
@@ -150,6 +152,7 @@ def _run_vertical_slice(*, input_path: str, work_dir: str, citation_limit: int =
         "summary": summary,
         "counts_by_stream": [{"stream": k, "count": counts[k]} for k in sorted(counts.keys())],
         "citations": citations,
+        "risk_flags": risk_flags,
         "policy": {"phi_tokens_checked": sorted(tokens), "phi_token_hits": []},
         "artifacts": {
             "run_dir": run_id,

--- a/healthdelta/risk_flags.py
+++ b/healthdelta/risk_flags.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DISCLAIMER = "Information-only risk flags for record review; not medical advice."
+
+
+def _parse_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _to_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _read_ndjson(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            out.append(row)
+    return out
+
+
+def _evidence(row: dict[str, Any], stream: str) -> dict[str, Any]:
+    return {
+        "stream": stream,
+        "record_key": row.get("record_key"),
+        "source_file": row.get("source_file"),
+        "event_time": row.get("event_time"),
+    }
+
+
+def build_risk_flags(*, ndjson_dir: str) -> dict[str, Any]:
+    root = Path(ndjson_dir)
+    observations = _read_ndjson(root / "observations.ndjson")
+    encounters = _read_ndjson(root / "encounters.ndjson")
+
+    bp_hits: list[dict[str, Any]] = []
+    tachy_hits: list[dict[str, Any]] = []
+    for row in observations:
+        value = _to_float(row.get("value"))
+        hk_type = row.get("hk_type")
+        codings = row.get("code_coding")
+        loinc_codes = set()
+        if isinstance(codings, list):
+            for coding in codings:
+                if isinstance(coding, dict) and coding.get("system") == "http://loinc.org" and isinstance(coding.get("code"), str):
+                    loinc_codes.add(coding["code"])
+
+        if value is not None:
+            if "8480-6" in loinc_codes and value >= 140:
+                bp_hits.append(row)
+            if "8462-4" in loinc_codes and value >= 90:
+                bp_hits.append(row)
+            if "8867-4" in loinc_codes and value >= 100:
+                tachy_hits.append(row)
+            if hk_type == "HKQuantityTypeIdentifierHeartRate" and value >= 100:
+                tachy_hits.append(row)
+
+    encounter_times = sorted([_parse_time(row.get("event_time")) for row in encounters if _parse_time(row.get("event_time")) is not None])
+    encounter_cluster = False
+    if len(encounter_times) >= 2:
+        for i in range(1, len(encounter_times)):
+            delta_days = (encounter_times[i] - encounter_times[i - 1]).days
+            if delta_days <= 30:
+                encounter_cluster = True
+                break
+
+    flags: list[dict[str, Any]] = []
+    if bp_hits:
+        flags.append(
+            {
+                "flag_id": "high_blood_pressure",
+                "category": "cardiovascular",
+                "severity": "high",
+                "title": "Elevated blood pressure reading observed",
+                "rationale": "One or more blood pressure measurements exceeded rule thresholds.",
+                "evidence": [_evidence(row, "observations") for row in bp_hits[:3]],
+            }
+        )
+    if tachy_hits:
+        flags.append(
+            {
+                "flag_id": "tachycardia_signal",
+                "category": "cardiovascular",
+                "severity": "medium",
+                "title": "Elevated heart-rate signal observed",
+                "rationale": "One or more heart-rate measurements met the tachycardia threshold.",
+                "evidence": [_evidence(row, "observations") for row in tachy_hits[:3]],
+            }
+        )
+    if encounter_cluster:
+        flags.append(
+            {
+                "flag_id": "frequent_recent_encounters",
+                "category": "utilization",
+                "severity": "medium",
+                "title": "Multiple encounters in a short interval",
+                "rationale": "Encounter timestamps indicate repeated care visits within 30 days.",
+                "evidence": [_evidence(row, "encounters") for row in encounters[:3]],
+            }
+        )
+
+    flags.sort(key=lambda row: (str(row.get("severity")), str(row.get("flag_id"))))
+    return {
+        "disclaimer": DISCLAIMER,
+        "flags": flags,
+    }

--- a/tests/test_backend_server.py
+++ b/tests/test_backend_server.py
@@ -64,6 +64,8 @@ class TestBackendServer(unittest.TestCase):
                     self.assertTrue(obj.get("ok"))
                     self.assertIn("summary", obj)
                     self.assertIn("citations", obj)
+                    self.assertIn("risk_flags", obj)
+                    self.assertIn("disclaimer", obj["risk_flags"])
                     self.assertGreater(len(obj["citations"]), 0)
                     blob = json.dumps(obj, sort_keys=True)
                     self.assertNotIn("John", blob)

--- a/tests/test_risk_flags.py
+++ b/tests/test_risk_flags.py
@@ -1,0 +1,92 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from healthdelta.risk_flags import build_risk_flags
+
+
+def _write_ndjson(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows)
+    path.write_text(text, encoding="utf-8")
+
+
+class TestRiskFlags(unittest.TestCase):
+    def test_build_risk_flags_is_deterministic_with_evidence_and_disclaimer(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_ndjson(
+                root / "observations.ndjson",
+                [
+                    {
+                        "record_key": "rk-bp",
+                        "source_file": "source/clinical/obs_bp.json",
+                        "event_time": "2020-01-01T00:00:00Z",
+                        "value": 150,
+                        "code_coding": [{"system": "http://loinc.org", "code": "8480-6"}],
+                    },
+                    {
+                        "record_key": "rk-hr",
+                        "source_file": "source/clinical/obs_hr.json",
+                        "event_time": "2020-01-02T00:00:00Z",
+                        "value": 110,
+                        "hk_type": "HKQuantityTypeIdentifierHeartRate",
+                    },
+                ],
+            )
+            _write_ndjson(
+                root / "encounters.ndjson",
+                [
+                    {
+                        "record_key": "rk-e1",
+                        "source_file": "source/clinical/e1.json",
+                        "event_time": "2020-01-10T00:00:00Z",
+                    },
+                    {
+                        "record_key": "rk-e2",
+                        "source_file": "source/clinical/e2.json",
+                        "event_time": "2020-01-20T00:00:00Z",
+                    },
+                ],
+            )
+
+            out1 = build_risk_flags(ndjson_dir=str(root))
+            out2 = build_risk_flags(ndjson_dir=str(root))
+            self.assertEqual(out1, out2)
+            self.assertIn("disclaimer", out1)
+            self.assertIn("not medical advice", out1["disclaimer"])
+            flags = out1["flags"]
+            ids = {row["flag_id"] for row in flags}
+            self.assertIn("high_blood_pressure", ids)
+            self.assertIn("tachycardia_signal", ids)
+            self.assertIn("frequent_recent_encounters", ids)
+            for row in flags:
+                self.assertIn("evidence", row)
+                self.assertGreater(len(row["evidence"]), 0)
+                for evidence in row["evidence"]:
+                    self.assertIn("record_key", evidence)
+                    self.assertIn("source_file", evidence)
+
+    def test_build_risk_flags_no_matches_still_has_disclaimer(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_ndjson(
+                root / "observations.ndjson",
+                [
+                    {
+                        "record_key": "rk-ok",
+                        "source_file": "source/clinical/obs_ok.json",
+                        "event_time": "2020-01-01T00:00:00Z",
+                        "value": 70,
+                        "code_coding": [{"system": "http://loinc.org", "code": "8867-4"}],
+                    }
+                ],
+            )
+            out = build_risk_flags(ndjson_dir=str(root))
+            self.assertEqual(out["flags"], [])
+            self.assertIn("not medical advice", out["disclaimer"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #124

## What
- add `healthdelta/risk_flags.py` with deterministic v1 rules and explicit severity/category/rationale output
- emit evidence links for each flag using canonical NDJSON references (`stream`, `record_key`, `source_file`, `event_time`)
- include mandatory non-medical-advice disclaimer with every risk-flag payload
- extend backend `POST /summary` response to include `risk_flags` and include it in PHI token guard scans
- add unit coverage for deterministic flag output, disclaimer presence, and evidence traceability
- update ORIN runbook + living plan status markers and add required `.ai/` audit artifacts

## Why
Issue #124 requires an information-only, auditable risk signal layer that remains deterministic and traceable to source records.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_risk_flags.py -v`
- `TZ=UTC python3 -m unittest tests/test_backend_server.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #124
