### PR TITLE
Issue: #125 trend analysis v1

### DIFF
--- a/.ai/prompts/issue_125.md
+++ b/.ai/prompts/issue_125.md
@@ -1,0 +1,22 @@
+---
+Story
+As a user,
+I want trend analysis over key clinical measures,
+So that changes over time are easy to interpret.
+
+Context / Why
+Trend analysis is a core mission capability and should follow once summary/risk vertical slices are proven.
+
+Acceptance Criteria
+- Given longitudinal observations, when trend analysis runs, then outputs include time-windowed trend direction and confidence markers.
+- Given missing/sparse data, when trend analysis runs, then outputs explicitly report insufficiency instead of guessing.
+- Given share-safe requirements, when trend outputs are emitted, then no direct identifiers are present.
+- Given test fixtures, when CI runs, then deterministic trend outputs are verified across repeated runs.
+
+Out of Scope
+- Predictive diagnosis.
+- Real-time streaming ingestion.
+
+Notes
+- Keep first version focused on a small fixed metric set.
+---

--- a/.ai/sessions/2026-02-02/session_5.md
+++ b/.ai/sessions/2026-02-02/session_5.md
@@ -1,0 +1,18 @@
+# Session 5 - 2026-02-02
+
+Issue: #125
+
+Goal
+- Add deterministic trend analysis v1 for longitudinal observations with explicit insufficiency output.
+
+Notes
+- Added `healthdelta/trends.py` for fixed metric trend windows (heart rate, systolic BP, diastolic BP).
+- Extended backend summary response with trend payload and PHI guard scanning coverage.
+- Added trend unit tests and backend response assertions.
+- Updated runbook and plan status markers for Issue #125.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_trends.py -v
+- TZ=UTC python3 -m unittest tests/test_backend_server.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -88,3 +88,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,122,UNASSIGNED,35,codex,UNASSIGNED,"ORIN local model/runtime matrix planning artifact + docs linkage"
 2026-02-02,123,UNASSIGNED,70,codex,UNASSIGNED,"Backend ingest->de-id->summary vertical slice API with citation and CI evidence artifacts"
 2026-02-02,124,UNASSIGNED,55,codex,UNASSIGNED,"Risk flags v1 deterministic ruleset with evidence traceability and disclaimer"
+2026-02-02,125,UNASSIGNED,50,codex,UNASSIGNED,"Trend analysis v1 payload with windowed direction/confidence and insufficiency handling"

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -61,9 +61,9 @@ New planning phase: Orin production deployment target (`orin.local`)
    - https://github.com/dave0875/HealthDelta/issues/122
 6) Issue #123 - Orin MMF: ingest-to-summary vertical slice on backend (closed)
    - https://github.com/dave0875/HealthDelta/issues/123
-7) Issue #124 - Orin MMF: risk flags v1 with evidence + disclaimers (active)
+7) Issue #124 - Orin MMF: risk flags v1 with evidence + disclaimers (closed)
    - https://github.com/dave0875/HealthDelta/issues/124
-8) Issue #125 - Orin MMF: trend analysis v1 for longitudinal records
+8) Issue #125 - Orin MMF: trend analysis v1 for longitudinal records (active)
    - https://github.com/dave0875/HealthDelta/issues/125
 9) Issue #126 - Orin MMF: grounded Q&A v1 with abstain behavior
    - https://github.com/dave0875/HealthDelta/issues/126

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -50,6 +50,7 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
   - deterministic stream-count summary text
   - citation list (`stream`, `record_key`, `source_file`, `event_time`, `line`)
   - deterministic risk flags (`flag_id`, `category`, `severity`, `rationale`, `evidence`)
+  - trend analysis (`metric`, `window_days`, `direction`, `confidence`, `delta`) with explicit insufficiency reporting
   - mandatory disclaimer string stating flags are not medical advice
   - PHI token guard check result (`phi_tokens_checked`, `phi_token_hits`)
 

--- a/healthdelta/backend_server.py
+++ b/healthdelta/backend_server.py
@@ -14,6 +14,7 @@ from healthdelta.identity import build_identity
 from healthdelta.ingest import ingest_to_staging
 from healthdelta.ndjson_export import export_ndjson
 from healthdelta.risk_flags import build_risk_flags
+from healthdelta.trends import build_trend_analysis
 from healthdelta.version import get_build_info
 
 
@@ -137,8 +138,11 @@ def _run_vertical_slice(*, input_path: str, work_dir: str, citation_limit: int =
 
     summary, citations, counts = _build_summary_from_ndjson(ndjson_dir, citation_limit=citation_limit)
     risk_flags = build_risk_flags(ndjson_dir=str(ndjson_dir))
+    trends = build_trend_analysis(ndjson_dir=str(ndjson_dir))
     tokens = _load_identity_tokens(identity_dir)
-    scan_text = "\n".join([summary, json.dumps(citations, sort_keys=True), json.dumps(risk_flags, sort_keys=True), "\n".join(log_lines)])
+    scan_text = "\n".join(
+        [summary, json.dumps(citations, sort_keys=True), json.dumps(risk_flags, sort_keys=True), json.dumps(trends, sort_keys=True), "\n".join(log_lines)]
+    )
     hits = _find_token_hits(scan_text, tokens)
     if hits:
         raise RuntimeError(f"policy failure: banned PHI tokens detected in output/logs: {', '.join(sorted(hits))}")
@@ -153,6 +157,7 @@ def _run_vertical_slice(*, input_path: str, work_dir: str, citation_limit: int =
         "counts_by_stream": [{"stream": k, "count": counts[k]} for k in sorted(counts.keys())],
         "citations": citations,
         "risk_flags": risk_flags,
+        "trends": trends,
         "policy": {"phi_tokens_checked": sorted(tokens), "phi_token_hits": []},
         "artifacts": {
             "run_dir": run_id,

--- a/healthdelta/trends.py
+++ b/healthdelta/trends.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _parse_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _to_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _read_ndjson(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            out.append(row)
+    return out
+
+
+def _metric_values(rows: list[dict[str, Any]], metric: str) -> list[tuple[datetime, float]]:
+    out: list[tuple[datetime, float]] = []
+    for row in rows:
+        when = _parse_time(row.get("event_time"))
+        if when is None:
+            continue
+        value = _to_float(row.get("value"))
+        if value is None:
+            continue
+        hk_type = row.get("hk_type")
+        codings = row.get("code_coding")
+        loinc_codes = set()
+        if isinstance(codings, list):
+            for coding in codings:
+                if isinstance(coding, dict) and coding.get("system") == "http://loinc.org" and isinstance(coding.get("code"), str):
+                    loinc_codes.add(coding["code"])
+        matches = False
+        if metric == "heart_rate":
+            matches = hk_type == "HKQuantityTypeIdentifierHeartRate" or "8867-4" in loinc_codes
+        elif metric == "systolic_bp":
+            matches = "8480-6" in loinc_codes
+        elif metric == "diastolic_bp":
+            matches = "8462-4" in loinc_codes
+        if matches:
+            out.append((when, value))
+    out.sort(key=lambda item: item[0])
+    return out
+
+
+def _trend_for_metric(*, metric: str, values: list[tuple[datetime, float]]) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "metric": metric,
+        "window_days": 7,
+        "direction": "insufficient",
+        "confidence": "insufficient",
+        "current_window_avg": None,
+        "previous_window_avg": None,
+        "delta": None,
+        "insufficiency_reason": "insufficient_data",
+    }
+    if len(values) < 3:
+        return base
+
+    latest = values[-1][0]
+    current_start = latest - timedelta(days=7)
+    previous_start = latest - timedelta(days=14)
+
+    current = [v for t, v in values if current_start <= t <= latest]
+    previous = [v for t, v in values if previous_start <= t < current_start]
+    if len(current) < 1 or len(previous) < 1:
+        return base
+
+    current_avg = sum(current) / len(current)
+    prev_avg = sum(previous) / len(previous)
+    delta = current_avg - prev_avg
+    abs_delta = abs(delta)
+
+    if abs_delta < 1.0:
+        direction = "stable"
+    elif delta > 0:
+        direction = "up"
+    else:
+        direction = "down"
+
+    sample_size = len(current) + len(previous)
+    if sample_size >= 8 and abs_delta >= 3.0:
+        confidence = "high"
+    elif sample_size >= 4:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    return {
+        "metric": metric,
+        "window_days": 7,
+        "direction": direction,
+        "confidence": confidence,
+        "current_window_avg": round(current_avg, 2),
+        "previous_window_avg": round(prev_avg, 2),
+        "delta": round(delta, 2),
+        "insufficiency_reason": None,
+    }
+
+
+def build_trend_analysis(*, ndjson_dir: str) -> dict[str, Any]:
+    rows = _read_ndjson(Path(ndjson_dir) / "observations.ndjson")
+    metrics = ["heart_rate", "systolic_bp", "diastolic_bp"]
+    trends = []
+    for metric in metrics:
+        values = _metric_values(rows, metric)
+        trends.append(_trend_for_metric(metric=metric, values=values))
+    return {"trends": trends}

--- a/tests/test_backend_server.py
+++ b/tests/test_backend_server.py
@@ -66,6 +66,8 @@ class TestBackendServer(unittest.TestCase):
                     self.assertIn("citations", obj)
                     self.assertIn("risk_flags", obj)
                     self.assertIn("disclaimer", obj["risk_flags"])
+                    self.assertIn("trends", obj)
+                    self.assertIn("trends", obj["trends"])
                     self.assertGreater(len(obj["citations"]), 0)
                     blob = json.dumps(obj, sort_keys=True)
                     self.assertNotIn("John", blob)

--- a/tests/test_trends.py
+++ b/tests/test_trends.py
@@ -1,0 +1,72 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from healthdelta.trends import build_trend_analysis
+
+
+def _write_ndjson(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows)
+    path.write_text(text, encoding="utf-8")
+
+
+class TestTrends(unittest.TestCase):
+    def test_trend_analysis_reports_direction_and_confidence(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_ndjson(
+                root / "observations.ndjson",
+                [
+                    {
+                        "event_time": "2020-01-01T00:00:00Z",
+                        "value": 70,
+                        "hk_type": "HKQuantityTypeIdentifierHeartRate",
+                    },
+                    {
+                        "event_time": "2020-01-03T00:00:00Z",
+                        "value": 72,
+                        "hk_type": "HKQuantityTypeIdentifierHeartRate",
+                    },
+                    {
+                        "event_time": "2020-01-09T00:00:00Z",
+                        "value": 90,
+                        "hk_type": "HKQuantityTypeIdentifierHeartRate",
+                    },
+                    {
+                        "event_time": "2020-01-10T00:00:00Z",
+                        "value": 95,
+                        "hk_type": "HKQuantityTypeIdentifierHeartRate",
+                    },
+                ],
+            )
+            out = build_trend_analysis(ndjson_dir=str(root))
+            by_metric = {row["metric"]: row for row in out["trends"]}
+            hr = by_metric["heart_rate"]
+            self.assertEqual(hr["direction"], "up")
+            self.assertIn(hr["confidence"], {"medium", "high"})
+            self.assertIsNone(hr["insufficiency_reason"])
+
+    def test_trend_analysis_reports_insufficient_for_sparse_data(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_ndjson(
+                root / "observations.ndjson",
+                [
+                    {
+                        "event_time": "2020-01-01T00:00:00Z",
+                        "value": 70,
+                        "code_coding": [{"system": "http://loinc.org", "code": "8480-6"}],
+                    }
+                ],
+            )
+            out = build_trend_analysis(ndjson_dir=str(root))
+            for row in out["trends"]:
+                self.assertEqual(row["direction"], "insufficient")
+                self.assertEqual(row["confidence"], "insufficient")
+                self.assertEqual(row["insufficiency_reason"], "insufficient_data")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #125

## What
- add deterministic trend-analysis module (`healthdelta/trends.py`) for core metrics: heart rate, systolic BP, diastolic BP
- compute 7-day vs prior-7-day trend direction (`up|down|stable`) with confidence markers and delta values
- emit explicit insufficiency results (`direction=insufficient`, `confidence=insufficient`) for sparse data
- extend backend `POST /summary` payload to include `trends`
- update ORIN runbook and plan status markers
- add deterministic unit tests for trend output and backend response shape

## Why
Issue #125 requires interpretable longitudinal trend output before moving to grounded Q&A and deployment hardening.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_trends.py -v`
- `TZ=UTC python3 -m unittest tests/test_backend_server.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #125
