### PR TITLE
Issue: #127 ORIN deployment + rollback proof hardening

### DIFF
--- a/.ai/prompts/issue_127.md
+++ b/.ai/prompts/issue_127.md
@@ -1,0 +1,22 @@
+---
+Story
+As an operator,
+I want a reproducible production deployment path for `orin.local`,
+So that backend releases can be installed, verified, and rolled back safely.
+
+Context / Why
+The repo has CI/release workflows, but Orin-specific deployment proof and operational checks are not yet codified.
+
+Acceptance Criteria
+- Given a tagged release artifact, when deployment procedure is executed on Orin, then backend service starts and serves `/healthz` and `/version`.
+- Given deployment validation, when smoke tests run, then risk/summary endpoints return expected shape against synthetic fixtures.
+- Given rollback requirements, when deployment fails, then documented rollback returns previous known-good version.
+- Given governance requirements, when deployment is declared ready, then CI/job/artifact evidence is referenced in runbook and issue closure notes.
+
+Out of Scope
+- Feature development for inference logic.
+- Remote shell automation tooling beyond deployment runbook needs.
+
+Notes
+- Prefer deterministic scripts and system service definitions over manual steps.
+---

--- a/.ai/sessions/2026-02-02/session_7.md
+++ b/.ai/sessions/2026-02-02/session_7.md
@@ -1,0 +1,17 @@
+# Session 7 - 2026-02-02
+
+Issue: #127
+
+Goal
+- Harden ORIN deploy/rollback proof path with endpoint shape verification and persisted evidence artifacts.
+
+Notes
+- Extended ORIN verify script to validate `/summary` and `/qa` endpoint shapes against synthetic fixtures.
+- Added deploy workflow artifact capture for endpoint responses (`summary_response.json`, `qa_response.json`).
+- Added deterministic rollback helper script `scripts/cd/orin_rollback_backend.sh`.
+- Updated deployment runbooks and plan status markers for Issue #127.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_backend_server.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -90,3 +90,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,124,UNASSIGNED,55,codex,UNASSIGNED,"Risk flags v1 deterministic ruleset with evidence traceability and disclaimer"
 2026-02-02,125,UNASSIGNED,50,codex,UNASSIGNED,"Trend analysis v1 payload with windowed direction/confidence and insufficiency handling"
 2026-02-02,126,UNASSIGNED,55,codex,UNASSIGNED,"Grounded local Q&A endpoint with citations, abstain behavior, and safety disclaimer"
+2026-02-02,127,UNASSIGNED,65,codex,UNASSIGNED,"ORIN deploy/rollback proof updates for summary+qa endpoint validation and persisted artifacts"

--- a/.github/workflows/deploy_backend_orin.yml
+++ b/.github/workflows/deploy_backend_orin.yml
@@ -77,6 +77,15 @@ jobs:
             DEPLOY_DIR="/opt/healthdelta" SERVICE_NAME="backend" BASE_URL="http://127.0.0.1:8080" \
             bash scripts/cd/orin_deploy_backend.sh | tee artifacts/orin-deploy/deploy_verify.log
 
+      - name: Capture endpoint response samples
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/orin-deploy
+          summary_payload='{"citation_limit":5,"input_path":"/app/tests/fixtures/profile_export"}'
+          qa_payload='{"citation_limit":5,"input_path":"/app/tests/fixtures/profile_export","question":"what observations exist?"}'
+          curl -fsS -X POST "http://127.0.0.1:8080/summary" -H "content-type: application/json" --data "$summary_payload" > artifacts/orin-deploy/summary_response.json
+          curl -fsS -X POST "http://127.0.0.1:8080/qa" -H "content-type: application/json" --data "$qa_payload" > artifacts/orin-deploy/qa_response.json
+
       - name: Record deploy metadata
         if: always()
         run: |
@@ -96,5 +105,7 @@ jobs:
           name: orin-deploy-proof
           path: |
             artifacts/orin-deploy/deploy_verify.log
+            artifacts/orin-deploy/summary_response.json
+            artifacts/orin-deploy/qa_response.json
             artifacts/orin-deploy/metadata.txt
           if-no-files-found: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY healthdelta ./healthdelta
+COPY tests/fixtures/profile_export ./tests/fixtures/profile_export
 
 ARG HEALTHDELTA_VERSION=0.0.0+container
 ARG HEALTHDELTA_GIT_SHA=unknown
@@ -15,4 +16,3 @@ ENV PORT=8080
 EXPOSE 8080
 
 CMD ["python", "-m", "healthdelta.backend_server"]
-

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -65,9 +65,9 @@ New planning phase: Orin production deployment target (`orin.local`)
    - https://github.com/dave0875/HealthDelta/issues/124
 8) Issue #125 - Orin MMF: trend analysis v1 for longitudinal records (closed)
    - https://github.com/dave0875/HealthDelta/issues/125
-9) Issue #126 - Orin MMF: grounded Q&A v1 with abstain behavior (active)
+9) Issue #126 - Orin MMF: grounded Q&A v1 with abstain behavior (closed)
    - https://github.com/dave0875/HealthDelta/issues/126
-10) Issue #127 - Orin MMF: production deployment + rollback proof on orin.local
+10) Issue #127 - Orin MMF: production deployment + rollback proof on orin.local (active)
     - https://github.com/dave0875/HealthDelta/issues/127
 11) Issue #128 - Orin MMF: CI safety guardrails for PHI leakage + disclosure requirements
     - https://github.com/dave0875/HealthDelta/issues/128

--- a/docs/runbook_cd.md
+++ b/docs/runbook_cd.md
@@ -63,8 +63,14 @@ Target host: `orin.local` (Jetson Orin Nano Super, local-only analytics).
 Deployment proof for Orin-target issues must include:
 - CI workflow/job evidence for build + tests tied to the issue.
 - Artifact evidence for deployment package contents and version metadata.
-- Smoke verification evidence from target-compatible run steps (`/healthz`, `/version`, and issue-scoped endpoint checks).
+- Smoke verification evidence from target-compatible run steps (`/healthz`, `/version`, `/summary`, `/qa`).
 - Rollback procedure evidence that restores a known-good version deterministically.
+
+For ORIN deploy proof artifacts, include:
+- `deploy_verify.log`
+- `summary_response.json`
+- `qa_response.json`
+- `metadata.txt`
 
 Planning/sequence is tracked by:
 - `docs/plan.md` Orin phase issues: #120-#128.

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -60,9 +60,13 @@ The deploy workflow verifies:
 - Correct image tag is running (container image contains `:vX.Y.Z`)
 - `GET /healthz` returns 200
 - `GET /version` returns `version=X.Y.Z` and `git_sha=<sha>`
+- `POST /summary` succeeds against synthetic fixture path and includes citations + risk/trend payload shape
+- `POST /qa` succeeds against synthetic fixture path and includes citations + disclaimer
 - Recent logs do not contain obvious fatal indicators (bounded tail scan)
 - Workflow uploads artifact `orin-deploy-proof` containing:
   - `deploy_verify.log`
+  - `summary_response.json`
+  - `qa_response.json`
   - `metadata.txt` (tag/version/sha/run URL)
 - CI Linux job also uploads backend slice evidence artifacts:
   - `artifacts/linux/backend_slice/smoke.log`
@@ -80,16 +84,18 @@ The deploy workflow verifies:
   - mandatory `qa.disclaimer` (not medical advice)
 
 ## Rollback
-1) Choose a previous tag (example: `v0.0.1`)
-2) Update `/opt/healthdelta/.env`:
-   - `HEALTHDELTA_BACKEND_IMAGE_TAG=v0.0.1`
-3) Redeploy:
-   - `cd /opt/healthdelta`
-   - `docker compose --env-file .env pull backend`
-   - `docker compose --env-file .env up -d --remove-orphans`
-4) Verify:
-   - `curl -fsS http://127.0.0.1:8080/healthz`
-   - `curl -fsS http://127.0.0.1:8080/version`
+Use deterministic rollback helper:
+
+```bash
+ROLLBACK_TAG=v0.0.1 ROLLBACK_SHA=<git_sha_for_tag> \
+  DEPLOY_DIR=/opt/healthdelta BASE_URL=http://127.0.0.1:8080 \
+  bash scripts/cd/orin_rollback_backend.sh
+```
+
+This script:
+- rewrites `/opt/healthdelta/.env` to the rollback tag
+- redeploys compose service
+- re-runs the same verify contract (`/healthz`, `/version`, `/summary`, `/qa`)
 
 ## Credentials / secrets
 - The workflow uses `GITHUB_TOKEN` for `docker login ghcr.io` with `packages: read` permission.

--- a/scripts/cd/orin_deploy_backend.sh
+++ b/scripts/cd/orin_deploy_backend.sh
@@ -35,5 +35,6 @@ docker compose --env-file .env pull "$SERVICE_NAME"
 docker compose --env-file .env up -d --remove-orphans
 
 DEPLOY_DIR="$DEPLOY_DIR" SERVICE_NAME="$SERVICE_NAME" BASE_URL="$BASE_URL" \
+  FIXTURE_INPUT_PATH="/app/tests/fixtures/profile_export" \
   EXPECTED_TAG="$TAG" EXPECTED_VERSION="$VERSION" EXPECTED_SHA="$GIT_SHA" \
   bash "$REPO_ROOT/scripts/cd/orin_verify_backend.sh"

--- a/scripts/cd/orin_rollback_backend.sh
+++ b/scripts/cd/orin_rollback_backend.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPLOY_DIR="${DEPLOY_DIR:-/opt/healthdelta}"
+SERVICE_NAME="${SERVICE_NAME:-backend}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+
+ROLLBACK_TAG="${ROLLBACK_TAG:?rollback tag (e.g., v0.0.5)}"
+ROLLBACK_VERSION="${ROLLBACK_VERSION:-${ROLLBACK_TAG#v}}"
+ROLLBACK_SHA="${ROLLBACK_SHA:?rollback git sha}"
+
+if [ ! -d "$DEPLOY_DIR" ]; then
+  echo "ERROR: deploy dir '$DEPLOY_DIR' is missing" >&2
+  exit 2
+fi
+if [ ! -w "$DEPLOY_DIR" ]; then
+  echo "ERROR: deploy dir '$DEPLOY_DIR' is not writable by user '$(id -un)'" >&2
+  exit 2
+fi
+
+cat >"$DEPLOY_DIR/.env" <<EOF
+HEALTHDELTA_BACKEND_IMAGE_TAG=$ROLLBACK_TAG
+EOF
+
+cd "$DEPLOY_DIR"
+docker compose --env-file .env pull "$SERVICE_NAME"
+docker compose --env-file .env up -d --remove-orphans
+
+DEPLOY_DIR="$DEPLOY_DIR" SERVICE_NAME="$SERVICE_NAME" BASE_URL="$BASE_URL" \
+  FIXTURE_INPUT_PATH="/app/tests/fixtures/profile_export" \
+  EXPECTED_TAG="$ROLLBACK_TAG" EXPECTED_VERSION="$ROLLBACK_VERSION" EXPECTED_SHA="$ROLLBACK_SHA" \
+  bash "$REPO_ROOT/scripts/cd/orin_verify_backend.sh"

--- a/scripts/cd/orin_verify_backend.sh
+++ b/scripts/cd/orin_verify_backend.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 DEPLOY_DIR="${DEPLOY_DIR:-/opt/healthdelta}"
 SERVICE_NAME="${SERVICE_NAME:-backend}"
 BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+FIXTURE_INPUT_PATH="${FIXTURE_INPUT_PATH:-/app/tests/fixtures/profile_export}"
 
 EXPECTED_TAG="${EXPECTED_TAG:?expected image tag (e.g., v0.0.2)}"
 EXPECTED_VERSION="${EXPECTED_VERSION:?expected version (e.g., 0.0.2)}"
@@ -59,6 +60,51 @@ if obj.get("git_sha") != expected_sha:
 print("ok")
 PY
 
+summary_payload="$(python3 - <<'PY'
+import json, os
+payload = {"input_path": os.environ["FIXTURE_INPUT_PATH"], "citation_limit": 5}
+print(json.dumps(payload, sort_keys=True))
+PY
+)"
+summary_json="$(curl -fsS -X POST "$BASE_URL/summary" -H 'content-type: application/json' --data "$summary_payload")"
+echo "$summary_json"
+SUMMARY_JSON="$summary_json" python3 - <<'PY'
+import json, os
+obj = json.loads(os.environ["SUMMARY_JSON"])
+if not isinstance(obj.get("summary"), str):
+    raise SystemExit("summary shape invalid: missing summary")
+if not isinstance(obj.get("citations"), list) or not obj.get("citations"):
+    raise SystemExit("summary shape invalid: citations missing")
+if not isinstance(obj.get("risk_flags"), dict) or "disclaimer" not in obj["risk_flags"]:
+    raise SystemExit("summary shape invalid: risk_flags missing")
+print("summary_ok")
+PY
+
+qa_payload="$(python3 - <<'PY'
+import json, os
+payload = {
+    "input_path": os.environ["FIXTURE_INPUT_PATH"],
+    "question": "what observations exist?",
+    "citation_limit": 5,
+}
+print(json.dumps(payload, sort_keys=True))
+PY
+)"
+qa_json="$(curl -fsS -X POST "$BASE_URL/qa" -H 'content-type: application/json' --data "$qa_payload")"
+echo "$qa_json"
+QA_JSON="$qa_json" python3 - <<'PY'
+import json, os
+obj = json.loads(os.environ["QA_JSON"])
+qa = obj.get("qa")
+if not isinstance(qa, dict):
+    raise SystemExit("qa shape invalid: missing qa object")
+if not isinstance(qa.get("citations"), list) or not qa["citations"]:
+    raise SystemExit("qa shape invalid: citations missing")
+if not isinstance(qa.get("disclaimer"), str) or "not medical advice" not in qa["disclaimer"].lower():
+    raise SystemExit("qa shape invalid: disclaimer missing")
+print("qa_ok")
+PY
+
 tail_logs="$(docker logs --tail 200 "$cid" 2>&1 || true)"
 echo "$tail_logs" | grep -E "Traceback \\(most recent call last\\)|\\bFATAL\\b|\\bCRITICAL\\b" >/dev/null && {
   echo "ERROR: fatal indicator found in recent logs" >&2
@@ -66,4 +112,3 @@ echo "$tail_logs" | grep -E "Traceback \\(most recent call last\\)|\\bFATAL\\b|\
 }
 
 echo "ok: verification passed"
-


### PR DESCRIPTION
Issue: #127

## What
- extend ORIN deploy verification to validate `/summary` and `/qa` endpoint response shape against synthetic fixture input
- add deterministic rollback helper `scripts/cd/orin_rollback_backend.sh` that redeploys a prior tag and re-runs full verify contract
- persist deploy evidence artifacts for endpoint samples (`summary_response.json`, `qa_response.json`) in `orin-deploy-proof`
- include synthetic profile fixture in backend image so ORIN smoke requests can run inside container context
- update ORIN deploy/CD runbooks and plan status markers

## Why
Issue #127 requires reproducible deployment + rollback proof on ORIN, including endpoint-level validation beyond health/version.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_backend_server.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`
- Run deploy workflow on a release tag and confirm `orin-deploy-proof` contains `deploy_verify.log`, `summary_response.json`, `qa_response.json`, `metadata.txt`

Closes #127
