### PR TITLE
Issue: #154 fix release fixture path for ORIN smoke checks

### DIFF
--- a/.ai/prompts/issue_154.md
+++ b/.ai/prompts/issue_154.md
@@ -1,0 +1,21 @@
+---
+Story
+As an operator,
+I want backend release builds to include the synthetic ORIN smoke fixture,
+So that deploy verification endpoints can run reliably on tagged releases.
+
+Context / Why
+Tag `v0.0.6` release backend image failed because Docker build context excluded `tests/` while Dockerfile tried to copy `tests/fixtures/profile_export`.
+
+Acceptance Criteria
+- Given a release build, when Docker image builds, then synthetic fixture copy succeeds without relying on excluded paths.
+- Given ORIN deploy verification, when `/summary` and `/qa` checks run, then fixture path is available in-container.
+- Given CI/release evidence, when a new tag is pushed, then Release and Deploy Backend (ORIN) workflows both succeed.
+
+Out of Scope
+- Changing verification semantics beyond fixture path correctness.
+- Adding new runtime dependencies.
+
+Notes
+- Keep fixture share-safe and minimal.
+---

--- a/.ai/sessions/2026-02-02/session_8.md
+++ b/.ai/sessions/2026-02-02/session_8.md
@@ -1,0 +1,16 @@
+# Session 8 - 2026-02-02
+
+Issue: #154
+
+Goal
+- Fix release image build context so ORIN endpoint smoke fixtures are present in-container.
+
+Notes
+- Moved deploy smoke fixture source to `deploy/fixtures/profile_export` (included by Docker build context).
+- Updated Dockerfile and ORIN deploy/rollback verification paths to `/app/deploy/fixtures/profile_export`.
+- Updated deploy workflow endpoint sample capture payload paths.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_backend_server.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -91,3 +91,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,125,UNASSIGNED,50,codex,UNASSIGNED,"Trend analysis v1 payload with windowed direction/confidence and insufficiency handling"
 2026-02-02,126,UNASSIGNED,55,codex,UNASSIGNED,"Grounded local Q&A endpoint with citations, abstain behavior, and safety disclaimer"
 2026-02-02,127,UNASSIGNED,65,codex,UNASSIGNED,"ORIN deploy/rollback proof updates for summary+qa endpoint validation and persisted artifacts"
+2026-02-02,154,UNASSIGNED,25,codex,UNASSIGNED,"Release image fixture path fix for ORIN summary/qa smoke checks"

--- a/.github/workflows/deploy_backend_orin.yml
+++ b/.github/workflows/deploy_backend_orin.yml
@@ -81,8 +81,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts/orin-deploy
-          summary_payload='{"citation_limit":5,"input_path":"/app/tests/fixtures/profile_export"}'
-          qa_payload='{"citation_limit":5,"input_path":"/app/tests/fixtures/profile_export","question":"what observations exist?"}'
+          summary_payload='{"citation_limit":5,"input_path":"/app/deploy/fixtures/profile_export"}'
+          qa_payload='{"citation_limit":5,"input_path":"/app/deploy/fixtures/profile_export","question":"what observations exist?"}'
           curl -fsS -X POST "http://127.0.0.1:8080/summary" -H "content-type: application/json" --data "$summary_payload" > artifacts/orin-deploy/summary_response.json
           curl -fsS -X POST "http://127.0.0.1:8080/qa" -H "content-type: application/json" --data "$qa_payload" > artifacts/orin-deploy/qa_response.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY healthdelta ./healthdelta
-COPY tests/fixtures/profile_export ./tests/fixtures/profile_export
+COPY deploy/fixtures/profile_export ./deploy/fixtures/profile_export
 
 ARG HEALTHDELTA_VERSION=0.0.0+container
 ARG HEALTHDELTA_GIT_SHA=unknown

--- a/deploy/fixtures/profile_export/clinical-records/1_patient.json
+++ b/deploy/fixtures/profile_export/clinical-records/1_patient.json
@@ -1,0 +1,7 @@
+{
+  "resourceType": "Patient",
+  "id": "p1",
+  "name": [{"text": "John Doe"}],
+  "birthDate": "1980-01-02"
+}
+

--- a/deploy/fixtures/profile_export/clinical-records/2_obs.json
+++ b/deploy/fixtures/profile_export/clinical-records/2_obs.json
@@ -1,0 +1,8 @@
+{
+  "resourceType": "Observation",
+  "id": "o1",
+  "status": "final",
+  "subject": {"display": "John Doe"},
+  "effectiveDateTime": "2020-01-01T01:02:03Z"
+}
+

--- a/deploy/fixtures/profile_export/clinical-records/3_doc.json
+++ b/deploy/fixtures/profile_export/clinical-records/3_doc.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "DocumentReference",
+  "id": "d1",
+  "status": "current",
+  "subject": {"display": "John Doe"},
+  "date": "2020-01-02T03:04:05Z",
+  "text": {"div": "John Doe discharge summary free text"}
+}
+

--- a/deploy/fixtures/profile_export/export.xml
+++ b/deploy/fixtures/profile_export/export.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<HealthData>
+  <Me name="John Doe" />
+  <Record type="HKQuantityTypeIdentifierHeartRate" unit="count/min" value="72" startDate="2020-01-01 00:00:00 -0500" endDate="2020-01-01 00:01:00 -0500"/>
+  <Record type="HKQuantityTypeIdentifierHeartRate" unit="count/min" value="75" startDate="2020-01-01 01:00:00 -0500" endDate="2020-01-01 01:01:00 -0500"/>
+  <Record type="HKQuantityTypeIdentifierStepCount" unit="count" value="123" startDate="2020-01-02 00:00:00 -0500" endDate="2020-01-02 00:05:00 -0500"/>
+</HealthData>
+

--- a/deploy/fixtures/profile_export/export_cda.xml
+++ b/deploy/fixtures/profile_export/export_cda.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3">
+  <recordTarget>
+    <patientRole>
+      <patient>
+        <name>John Doe</name>
+        <birthTime value="19800102"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="8867-4" displayName="Heart rate"/>
+              <value xsi:type="PQ" value="72" unit="/min" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+            </observation>
+          </entry>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="8310-5" displayName="Body temperature"/>
+              <value xsi:type="PQ" value="37.0" unit="Cel" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+            </observation>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>
+

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -62,6 +62,7 @@ The deploy workflow verifies:
 - `GET /version` returns `version=X.Y.Z` and `git_sha=<sha>`
 - `POST /summary` succeeds against synthetic fixture path and includes citations + risk/trend payload shape
 - `POST /qa` succeeds against synthetic fixture path and includes citations + disclaimer
+- Synthetic fixture path used in-container: `/app/deploy/fixtures/profile_export`
 - Recent logs do not contain obvious fatal indicators (bounded tail scan)
 - Workflow uploads artifact `orin-deploy-proof` containing:
   - `deploy_verify.log`

--- a/scripts/cd/orin_deploy_backend.sh
+++ b/scripts/cd/orin_deploy_backend.sh
@@ -35,6 +35,6 @@ docker compose --env-file .env pull "$SERVICE_NAME"
 docker compose --env-file .env up -d --remove-orphans
 
 DEPLOY_DIR="$DEPLOY_DIR" SERVICE_NAME="$SERVICE_NAME" BASE_URL="$BASE_URL" \
-  FIXTURE_INPUT_PATH="/app/tests/fixtures/profile_export" \
+  FIXTURE_INPUT_PATH="/app/deploy/fixtures/profile_export" \
   EXPECTED_TAG="$TAG" EXPECTED_VERSION="$VERSION" EXPECTED_SHA="$GIT_SHA" \
   bash "$REPO_ROOT/scripts/cd/orin_verify_backend.sh"

--- a/scripts/cd/orin_rollback_backend.sh
+++ b/scripts/cd/orin_rollback_backend.sh
@@ -28,6 +28,6 @@ docker compose --env-file .env pull "$SERVICE_NAME"
 docker compose --env-file .env up -d --remove-orphans
 
 DEPLOY_DIR="$DEPLOY_DIR" SERVICE_NAME="$SERVICE_NAME" BASE_URL="$BASE_URL" \
-  FIXTURE_INPUT_PATH="/app/tests/fixtures/profile_export" \
+  FIXTURE_INPUT_PATH="/app/deploy/fixtures/profile_export" \
   EXPECTED_TAG="$ROLLBACK_TAG" EXPECTED_VERSION="$ROLLBACK_VERSION" EXPECTED_SHA="$ROLLBACK_SHA" \
   bash "$REPO_ROOT/scripts/cd/orin_verify_backend.sh"


### PR DESCRIPTION
Issue: #154

## What
- move ORIN smoke fixture into Docker-included path `deploy/fixtures/profile_export`
- update Dockerfile to copy deploy fixture path (instead of excluded `tests/` path)
- update ORIN deploy/rollback scripts and deploy workflow sample payloads to use `/app/deploy/fixtures/profile_export`
- update ORIN runbook fixture path reference
- add required `.ai/` prompt/session/time audit artifacts for this fix issue

## Why
Tag `v0.0.6` backend image failed to build because `.dockerignore` excludes `tests/` while Dockerfile copied `tests/fixtures/profile_export`.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_backend_server.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`
- Push a new release tag and confirm Release + Deploy Backend workflows succeed with endpoint sample artifacts.

Closes #154
