### PR TITLE
Issue: #128 CI safety guardrails for PHI/disclaimer/citations

### DIFF
--- a/.ai/prompts/issue_128.md
+++ b/.ai/prompts/issue_128.md
@@ -1,0 +1,22 @@
+---
+Story
+As a maintainer,
+I want PHI-leakage and safety guardrail tests enforced in CI,
+So that local inference outputs remain share-safe and auditable.
+
+Context / Why
+Planning and deployment are insufficient without automated checks for PHI leakage, disclaimer presence, and citation/traceability requirements.
+
+Acceptance Criteria
+- Given inference outputs/logs from synthetic fixtures, when CI checks run, then banned PHI patterns are rejected.
+- Given summary/risk/trend/Q&A outputs, when validation runs, then required disclaimer and citation fields are enforced.
+- Given failures, when CI reports results, then artifacts include machine-readable safety check logs.
+- Given merge criteria, when guardrails fail, then PR status is blocking.
+
+Out of Scope
+- Clinical quality evaluation beyond safety/compliance guardrails.
+- Human reviewer UI.
+
+Notes
+- This issue is a quality gate for Orin feature issues.
+---

--- a/.ai/sessions/2026-02-02/session_9.md
+++ b/.ai/sessions/2026-02-02/session_9.md
@@ -1,0 +1,17 @@
+# Session 9 - 2026-02-02
+
+Issue: #128
+
+Goal
+- Add blocking CI safety guardrails for PHI leakage and output contract requirements.
+
+Notes
+- Added `scripts/check_safety_outputs.py` to run local summary + QA checks and enforce banned-token/disclaimer/citation contracts.
+- Added CI safety validation step and artifact uploads (`safety_report.json`, `safety.log`).
+- Added deterministic unit tests for safety validation behavior.
+- Updated runbook and plan status markers for Issue #128.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_safety_checks.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -92,3 +92,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,126,UNASSIGNED,55,codex,UNASSIGNED,"Grounded local Q&A endpoint with citations, abstain behavior, and safety disclaimer"
 2026-02-02,127,UNASSIGNED,65,codex,UNASSIGNED,"ORIN deploy/rollback proof updates for summary+qa endpoint validation and persisted artifacts"
 2026-02-02,154,UNASSIGNED,25,codex,UNASSIGNED,"Release image fixture path fix for ORIN summary/qa smoke checks"
+2026-02-02,128,UNASSIGNED,45,codex,UNASSIGNED,"Blocking CI safety guardrails for PHI patterns and output disclaimer/citation contracts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,16 @@ jobs:
             --response artifacts/linux/backend_slice/summary_response.json \
             --log artifacts/linux/backend_slice/smoke.log
 
+      - name: Run safety guardrail validation (artifact evidence)
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/linux/safety
+          python3 scripts/check_safety_outputs.py \
+            --input tests/fixtures/profile_export \
+            --work artifacts/linux/safety/work \
+            --out-json artifacts/linux/safety/safety_report.json \
+            --out-log artifacts/linux/safety/safety.log
+
       - name: Upload Linux unittest artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -118,6 +128,8 @@ jobs:
             artifacts/linux/profile/sensitive_field_map.json
             artifacts/linux/backend_slice/smoke.log
             artifacts/linux/backend_slice/summary_response.json
+            artifacts/linux/safety/safety_report.json
+            artifacts/linux/safety/safety.log
           if-no-files-found: error
 
       - name: Fail if policy or unittest failed

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -67,9 +67,9 @@ New planning phase: Orin production deployment target (`orin.local`)
    - https://github.com/dave0875/HealthDelta/issues/125
 9) Issue #126 - Orin MMF: grounded Q&A v1 with abstain behavior (closed)
    - https://github.com/dave0875/HealthDelta/issues/126
-10) Issue #127 - Orin MMF: production deployment + rollback proof on orin.local (active)
+10) Issue #127 - Orin MMF: production deployment + rollback proof on orin.local (closed)
     - https://github.com/dave0875/HealthDelta/issues/127
-11) Issue #128 - Orin MMF: CI safety guardrails for PHI leakage + disclosure requirements
+11) Issue #128 - Orin MMF: CI safety guardrails for PHI leakage + disclosure requirements (active)
     - https://github.com/dave0875/HealthDelta/issues/128
 
 ## Operating rules (quick reference)

--- a/docs/runbook_cd.md
+++ b/docs/runbook_cd.md
@@ -11,6 +11,7 @@ This runbook defines how HealthDelta produces share-safe build artifacts and wha
   - Linux uploads deterministic evidence artifacts:
     - `linux-unittest` (`python_version.txt`, `unittest.log`)
     - `ndjson_validate.log` smoke validation output
+    - `safety_report.json` + `safety.log` guardrail validation outputs
   - macOS job passes and uploads `ios-xcresult`.
 - Governance hardening behavior:
   - Governance checks are rewrite-tolerant and never crash on missing commit ranges.

--- a/scripts/check_safety_outputs.py
+++ b/scripts/check_safety_outputs.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import threading
+import time
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from healthdelta.backend_server import make_server
+
+
+BANNED_PATTERNS = [
+    re.compile(r"\bJohn\b", re.IGNORECASE),
+    re.compile(r"\bDoe\b", re.IGNORECASE),
+    re.compile(r"\b1980-01-02\b"),
+]
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _json_post(url: str, payload: dict) -> dict:
+    req = Request(
+        url,
+        data=json.dumps(payload, sort_keys=True).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(req) as resp:
+        body = resp.read().decode("utf-8")
+        return json.loads(body)
+
+
+def _validate_summary(summary_obj: dict, errors: list[str]) -> None:
+    if not isinstance(summary_obj.get("citations"), list) or not summary_obj.get("citations"):
+        errors.append("summary.citations missing or empty")
+    risk = summary_obj.get("risk_flags")
+    if not isinstance(risk, dict):
+        errors.append("summary.risk_flags missing")
+    else:
+        disclaimer = risk.get("disclaimer")
+        if not isinstance(disclaimer, str) or "not medical advice" not in disclaimer.lower():
+            errors.append("summary.risk_flags.disclaimer missing or invalid")
+    trends = summary_obj.get("trends")
+    if not isinstance(trends, dict) or not isinstance(trends.get("trends"), list):
+        errors.append("summary.trends missing or invalid")
+
+
+def _validate_qa(qa_obj: dict, errors: list[str]) -> None:
+    qa = qa_obj.get("qa")
+    if not isinstance(qa, dict):
+        errors.append("qa.qa missing")
+        return
+    disclaimer = qa.get("disclaimer")
+    if not isinstance(disclaimer, str) or "not medical advice" not in disclaimer.lower():
+        errors.append("qa.disclaimer missing or invalid")
+    citations = qa.get("citations")
+    abstained = bool(qa.get("abstained"))
+    if not isinstance(citations, list):
+        errors.append("qa.citations missing")
+    elif not citations and not abstained:
+        errors.append("qa.citations empty without abstain")
+    if abstained and "insufficient evidence" not in str(qa.get("answer", "")).lower():
+        errors.append("qa.abstained without insufficiency message")
+
+
+def _check_banned(text: str, errors: list[str]) -> None:
+    for pat in BANNED_PATTERNS:
+        if pat.search(text):
+            errors.append(f"banned_pattern_detected:{pat.pattern}")
+
+
+def run_safety_check(*, input_path: str, work_dir: str) -> dict:
+    server = make_server(host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(0.05)
+    host, port = server.server_address
+    base_url = f"http://{host}:{port}"
+
+    errors: list[str] = []
+    summary_obj: dict = {}
+    qa_obj: dict = {}
+    try:
+        summary_obj = _json_post(
+            base_url + "/summary",
+            {"input_path": str(Path(input_path).resolve()), "work_dir": str(Path(work_dir).resolve()), "citation_limit": 8},
+        )
+        qa_obj = _json_post(
+            base_url + "/qa",
+            {
+                "input_path": str(Path(input_path).resolve()),
+                "work_dir": str(Path(work_dir).resolve()),
+                "question": "what observations exist?",
+                "citation_limit": 8,
+            },
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    _validate_summary(summary_obj, errors)
+    _validate_qa(qa_obj, errors)
+    summary_scan = "\n".join(
+        [
+            str(summary_obj.get("summary", "")),
+            json.dumps(summary_obj.get("citations", []), sort_keys=True),
+            json.dumps((summary_obj.get("risk_flags") or {}).get("flags", []), sort_keys=True),
+            json.dumps((summary_obj.get("trends") or {}).get("trends", []), sort_keys=True),
+        ]
+    )
+    qa_payload = qa_obj.get("qa") if isinstance(qa_obj.get("qa"), dict) else {}
+    qa_scan = "\n".join(
+        [
+            str(qa_payload.get("answer", "")),
+            str(qa_payload.get("disclaimer", "")),
+            json.dumps(qa_payload.get("citations", []), sort_keys=True),
+        ]
+    )
+    _check_banned(summary_scan, errors)
+    _check_banned(qa_scan, errors)
+
+    return {
+        "ok": len(errors) == 0,
+        "errors": errors,
+        "summary": summary_obj,
+        "qa": qa_obj,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Validate share-safe endpoint outputs and guardrails.")
+    p.add_argument("--input", required=True, help="Synthetic fixture input directory")
+    p.add_argument("--work", required=True, help="Working directory for generated artifacts")
+    p.add_argument("--out-json", required=True, help="Machine-readable report output path")
+    p.add_argument("--out-log", required=True, help="Human log output path")
+    args = p.parse_args(argv)
+
+    report = run_safety_check(input_path=args.input, work_dir=args.work)
+    _write(Path(args.out_json), json.dumps(report, sort_keys=True, indent=2) + "\n")
+    log_lines = [f"ok={str(report['ok']).lower()}"]
+    for err in report["errors"]:
+        log_lines.append(f"error={err}")
+    if report["ok"]:
+        log_lines.append("safety checks passed")
+    _write(Path(args.out_log), "\n".join(log_lines) + "\n")
+
+    if not report["ok"]:
+        print("\n".join(log_lines))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_safety_checks.py
+++ b/tests/test_safety_checks.py
@@ -1,0 +1,46 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "check_safety_outputs.py"
+    spec = importlib.util.spec_from_file_location("check_safety_outputs", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestSafetyChecks(unittest.TestCase):
+    def test_run_safety_check_passes_for_fixture(self) -> None:
+        mod = _load_module()
+        with tempfile.TemporaryDirectory() as td:
+            report = mod.run_safety_check(
+                input_path="tests/fixtures/profile_export",
+                work_dir=str(Path(td) / "work"),
+            )
+            self.assertTrue(report["ok"], msg=json.dumps(report, sort_keys=True))
+            self.assertEqual(report["errors"], [])
+
+    def test_validate_qa_requires_insufficiency_message_on_abstain(self) -> None:
+        mod = _load_module()
+        errors: list[str] = []
+        mod._validate_qa(
+            {
+                "qa": {
+                    "abstained": True,
+                    "answer": "No data.",
+                    "disclaimer": "not medical advice",
+                    "citations": [],
+                }
+            },
+            errors,
+        )
+        self.assertIn("qa.abstained without insufficiency message", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #128

## What
- add `scripts/check_safety_outputs.py` to execute local summary+QA endpoint checks and enforce safety contracts
- enforce banned PHI token patterns on endpoint output payload text
- enforce required disclaimer/citation contracts across summary/risk/trends/QA output shapes
- write machine-readable CI safety artifacts: `safety_report.json` and `safety.log`
- add blocking CI step for safety validation and include artifacts in Linux upload bundle
- add deterministic unit tests for safety checks and update docs/plan status markers

## Why
Issue #128 is the quality gate that blocks merges when PHI leakage/disclaimer/citation contracts regress.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_safety_checks.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #128
