### PR TITLE
Issue: #92 CI governance evidence artifact hardening

### DIFF
--- a/.ai/prompts/issue_92.md
+++ b/.ai/prompts/issue_92.md
@@ -1,0 +1,23 @@
+---
+Story
+As a maintainer,
+I want CI guardrails that enforce governance and issue discipline automatically,
+So that “one issue per PR” and required audit artifacts are programmatically guaranteed.
+
+Context / Why
+Recent work was done across multiple issues before PRs/CI; this must be prevented by guardrails rather than manual discipline.
+
+Acceptance Criteria
+- Given a PR, when CI runs, then it fails if commit messages contain more than one distinct `Issue: #NN` value (enforce one issue per PR).
+- Given a PR, when CI runs, then it fails if the PR title/body does not include the same `Issue: #NN`.
+- Given code or docs changes (excluding `.ai/`), when CI runs, then it fails if `.ai/prompts/issue_N.md`, a session entry for today, and a `.ai/time/time.csv` line for that Issue are missing.
+- Given changes to `.ai/prompts/issue_N.md`, when CI runs, then it fails unless the file is new (immutability enforcement).
+- CI uploads required evidence artifacts for tests/validation (logs + results) with deterministic names.
+
+Out of Scope
+- Changing acceptance criteria for existing issues.
+- Non-CI enforcement (local hooks) unless explicitly added in a follow-up issue.
+
+Notes
+- Prefer repository-local scripts; avoid network calls in CI.
+---

--- a/.ai/sessions/2026-02-02/session_10.md
+++ b/.ai/sessions/2026-02-02/session_10.md
@@ -1,0 +1,17 @@
+# Session 10 - 2026-02-02
+
+Issue: #92
+
+Goal
+- Add deterministic CI evidence for governance guardrails and keep issue-discipline checks machine-auditable.
+
+Notes
+- Added `scripts/render_policy_report.py` to produce machine-readable governance outcome reports.
+- Added CI policy-report step and artifact upload (`artifacts/linux/policy/policy_report.json`).
+- Added unit tests for policy report generation.
+- Updated CD runbook and plan status markers.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_policy_report.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -93,3 +93,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,127,UNASSIGNED,65,codex,UNASSIGNED,"ORIN deploy/rollback proof updates for summary+qa endpoint validation and persisted artifacts"
 2026-02-02,154,UNASSIGNED,25,codex,UNASSIGNED,"Release image fixture path fix for ORIN summary/qa smoke checks"
 2026-02-02,128,UNASSIGNED,45,codex,UNASSIGNED,"Blocking CI safety guardrails for PHI patterns and output disclaimer/citation contracts"
+2026-02-02,92,UNASSIGNED,35,codex,UNASSIGNED,"CI governance artifact report for deterministic issue-discipline evidence"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,19 @@ jobs:
             --out-json artifacts/linux/safety/safety_report.json \
             --out-log artifacts/linux/safety/safety.log
 
+      - name: Render policy outcome report (artifact evidence)
+        if: always()
+        env:
+          POLICY_ISSUE_FOOTER: ${{ steps.policy_issue_footer.outcome }}
+          POLICY_PR_ISSUE: ${{ steps.policy_pr_issue.outcome }}
+          POLICY_AUDIT_ARTIFACTS: ${{ steps.policy_audit_artifacts.outcome }}
+          POLICY_PROMPT_IMMUTABILITY: ${{ steps.policy_prompt_immutability.outcome }}
+          POLICY_WORKTREE: ${{ steps.policy_worktree.outcome }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/linux/policy
+          python3 scripts/render_policy_report.py --out artifacts/linux/policy/policy_report.json
+
       - name: Upload Linux unittest artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -130,6 +143,7 @@ jobs:
             artifacts/linux/backend_slice/summary_response.json
             artifacts/linux/safety/safety_report.json
             artifacts/linux/safety/safety.log
+            artifacts/linux/policy/policy_report.json
           if-no-files-found: error
 
       - name: Fail if policy or unittest failed

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -47,9 +47,9 @@ Completed
 - Issue #117 is closed (managed hidden worktree root + auto-prune + CI path guardrail).
 
 Active governance carryover
-1) Issue #72 - Governance: plan refresh + CI issue reference gate
+1) Issue #72 - Governance: plan refresh + CI issue reference gate (active)
    - https://github.com/dave0875/HealthDelta/issues/72
-2) Issue #92 - Governance: CI guardrails for issue discipline
+2) Issue #92 - Governance: CI guardrails for issue discipline (active)
    - https://github.com/dave0875/HealthDelta/issues/92
 
 New planning phase: Orin production deployment target (`orin.local`)
@@ -69,7 +69,7 @@ New planning phase: Orin production deployment target (`orin.local`)
    - https://github.com/dave0875/HealthDelta/issues/126
 10) Issue #127 - Orin MMF: production deployment + rollback proof on orin.local (closed)
     - https://github.com/dave0875/HealthDelta/issues/127
-11) Issue #128 - Orin MMF: CI safety guardrails for PHI leakage + disclosure requirements (active)
+11) Issue #128 - Orin MMF: CI safety guardrails for PHI leakage + disclosure requirements (closed)
     - https://github.com/dave0875/HealthDelta/issues/128
 
 ## Operating rules (quick reference)

--- a/docs/runbook_cd.md
+++ b/docs/runbook_cd.md
@@ -12,6 +12,7 @@ This runbook defines how HealthDelta produces share-safe build artifacts and wha
     - `linux-unittest` (`python_version.txt`, `unittest.log`)
     - `ndjson_validate.log` smoke validation output
     - `safety_report.json` + `safety.log` guardrail validation outputs
+    - `policy_report.json` governance check outcomes (machine-readable)
   - macOS job passes and uploads `ios-xcresult`.
 - Governance hardening behavior:
   - Governance checks are rewrite-tolerant and never crash on missing commit ranges.

--- a/scripts/render_policy_report.py
+++ b/scripts/render_policy_report.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+POLICY_KEYS = [
+    "POLICY_ISSUE_FOOTER",
+    "POLICY_PR_ISSUE",
+    "POLICY_AUDIT_ARTIFACTS",
+    "POLICY_PROMPT_IMMUTABILITY",
+    "POLICY_WORKTREE",
+]
+
+
+def _status(raw: str) -> str:
+    x = (raw or "").strip().lower()
+    if x in {"success", "failure", "cancelled", "skipped"}:
+        return x
+    if not x:
+        return "unknown"
+    return "unknown"
+
+
+def build_report(env: dict[str, str]) -> dict:
+    rows = []
+    any_failure = False
+    for key in POLICY_KEYS:
+        value = _status(env.get(key, ""))
+        rows.append({"check": key.lower(), "outcome": value})
+        if value == "failure":
+            any_failure = True
+    return {
+        "policy_checks": rows,
+        "any_failure": any_failure,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Render machine-readable policy outcome report.")
+    p.add_argument("--out", required=True, help="Output JSON report path")
+    args = p.parse_args(argv)
+    report = build_report(dict(os.environ))
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_policy_report.py
+++ b/tests/test_policy_report.py
@@ -1,0 +1,45 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "render_policy_report.py"
+    spec = importlib.util.spec_from_file_location("render_policy_report", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestPolicyReport(unittest.TestCase):
+    def test_build_report_marks_failure(self) -> None:
+        mod = _load_module()
+        report = mod.build_report(
+            {
+                "POLICY_ISSUE_FOOTER": "success",
+                "POLICY_PR_ISSUE": "failure",
+                "POLICY_AUDIT_ARTIFACTS": "success",
+                "POLICY_PROMPT_IMMUTABILITY": "success",
+                "POLICY_WORKTREE": "success",
+            }
+        )
+        self.assertTrue(report["any_failure"])
+        outcomes = {row["check"]: row["outcome"] for row in report["policy_checks"]}
+        self.assertEqual(outcomes["policy_pr_issue"], "failure")
+
+    def test_script_writes_json_report(self) -> None:
+        mod = _load_module()
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "policy_report.json"
+            report = mod.build_report({})
+            out.write_text(json.dumps(report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+            loaded = json.loads(out.read_text(encoding="utf-8"))
+            self.assertIn("policy_checks", loaded)
+            self.assertIn("any_failure", loaded)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #92

## What
- add `scripts/render_policy_report.py` to emit machine-readable governance outcomes from CI policy check steps
- add CI step to render and upload deterministic governance evidence artifact: `artifacts/linux/policy/policy_report.json`
- extend Linux artifact bundle with policy report evidence
- add unit tests for policy report generation
- update CD runbook and plan status markers

## Why
Issue #92 requires CI-enforced governance with deterministic, auditable evidence artifacts for policy outcomes.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_policy_report.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #92
