### PR TITLE
Issue: #72 plan refresh + CI issue gate test coverage

### DIFF
--- a/.ai/sessions/2026-02-02/session_11.md
+++ b/.ai/sessions/2026-02-02/session_11.md
@@ -1,0 +1,16 @@
+# Session 11 - 2026-02-02
+
+Issue: #72
+
+Goal
+- Refresh living plan status and add deterministic CI policy-config tests for issue-reference enforcement.
+
+Notes
+- Added CI policy configuration tests validating issue footer and PR issue gate wiring in `.github/workflows/ci.yml`.
+- Refreshed `docs/plan.md` status and post-MMF roadmap.
+- Updated CD runbook to reference issue-gate scripts explicitly.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_ci_policy_config.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v
+- TZ=UTC python3 -m unittest discover -s tests -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -94,3 +94,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,154,UNASSIGNED,25,codex,UNASSIGNED,"Release image fixture path fix for ORIN summary/qa smoke checks"
 2026-02-02,128,UNASSIGNED,45,codex,UNASSIGNED,"Blocking CI safety guardrails for PHI patterns and output disclaimer/citation contracts"
 2026-02-02,92,UNASSIGNED,35,codex,UNASSIGNED,"CI governance artifact report for deterministic issue-discipline evidence"
+2026-02-02,72,UNASSIGNED,30,codex,UNASSIGNED,"Plan refresh and deterministic CI issue-reference gate coverage tests"

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -49,11 +49,11 @@ Completed
 Active governance carryover
 1) Issue #72 - Governance: plan refresh + CI issue reference gate (active)
    - https://github.com/dave0875/HealthDelta/issues/72
-2) Issue #92 - Governance: CI guardrails for issue discipline (active)
+2) Issue #92 - Governance: CI guardrails for issue discipline (closed)
    - https://github.com/dave0875/HealthDelta/issues/92
 
 New planning phase: Orin production deployment target (`orin.local`)
-3) Issue #120 - Planning: Orin production deployment MMF backlog
+3) Issue #120 - Planning: Orin production deployment MMF backlog (closed)
    - https://github.com/dave0875/HealthDelta/issues/120
 4) Issue #121 - Orin MMF: export inventory + PHI field map (closed)
    - https://github.com/dave0875/HealthDelta/issues/121
@@ -71,6 +71,11 @@ New planning phase: Orin production deployment target (`orin.local`)
     - https://github.com/dave0875/HealthDelta/issues/127
 11) Issue #128 - Orin MMF: CI safety guardrails for PHI leakage + disclosure requirements (closed)
     - https://github.com/dave0875/HealthDelta/issues/128
+
+Next roadmap focus (post-MMF)
+- Harden performance envelopes on ORIN with benchmark artifacts and regression thresholds.
+- Expand risk/trend rule coverage with stricter clinical evidence mappings.
+- Add operator-facing runbook automation for routine rollback drills and release readiness checks.
 
 ## Operating rules (quick reference)
 

--- a/docs/runbook_cd.md
+++ b/docs/runbook_cd.md
@@ -16,6 +16,7 @@ This runbook defines how HealthDelta produces share-safe build artifacts and wha
   - macOS job passes and uploads `ios-xcresult`.
 - Governance hardening behavior:
   - Governance checks are rewrite-tolerant and never crash on missing commit ranges.
+  - Issue-reference gate is enforced by `scripts/check_issue_footer.py` and `scripts/check_pr_issue.py`.
   - Tests/build execution still runs when policy checks fail.
   - Governance failures are reported as explicit `policy failure` outcomes (not infra failures).
 

--- a/tests/test_ci_policy_config.py
+++ b/tests/test_ci_policy_config.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import unittest
+
+
+class TestCIPolicyConfig(unittest.TestCase):
+    def test_ci_workflow_has_issue_reference_gate(self) -> None:
+        ci = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn("Enforce Issue footer in commit messages", ci)
+        self.assertIn("python3 scripts/check_issue_footer.py", ci)
+        self.assertIn("Enforce PR Issue metadata", ci)
+        self.assertIn("python3 scripts/check_pr_issue.py", ci)
+
+    def test_ci_policy_failure_step_is_blocking(self) -> None:
+        ci = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn("Fail if policy or unittest failed", ci)
+        self.assertIn("policy failure: one or more governance checks failed.", ci)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #72

## What
- refresh `docs/plan.md` to current status (MMF issues closed and governance carryover clarity)
- add deterministic CI config tests (`tests/test_ci_policy_config.py`) that assert issue-reference gate wiring and blocking policy failure behavior
- update CD runbook to explicitly reference issue-gate scripts
- add required `.ai/` session + time tracking updates

## Why
Issue #72 requires a living plan refresh and durable CI enforcement evidence that issue references are required for changes.

## How to verify
- `TZ=UTC python3 -m unittest tests/test_ci_policy_config.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`
- `TZ=UTC python3 -m unittest discover -s tests -v`

Closes #72
