### PR TITLE
iOS dashboard for sync status and insights (#159)

### DIFF
--- a/.ai/prompts/issue_159.md
+++ b/.ai/prompts/issue_159.md
@@ -1,0 +1,13 @@
+# Issue #159 Prompt (Immutable)
+
+Implement iOS UI for sync status and health insights.
+
+Scope:
+- Replace placeholder iOS screen with a Nielsen-heuristics-oriented dashboard.
+- Show sync visibility at launch: last sync time, last delta window, exported rows/bytes, and anchor status.
+- Add sync details view with deterministic run metadata (run id, files, counts, anchors) without PHI text.
+- Add insights section that surfaces share-safe artifacts (Doctor's Note and summary) with disclaimer and freshness context.
+- Handle first-run empty state with explicit next steps.
+- Add iOS unit tests for deterministic formatting/state mapping for sync status and insight cards.
+
+Do not add cloud/account features or clinical diagnosis functionality.

--- a/.ai/sessions/2026-02-02/session_12.md
+++ b/.ai/sessions/2026-02-02/session_12.md
@@ -1,0 +1,16 @@
+# Session 12 - 2026-02-02
+
+Issue: #159
+
+Goal
+- Build the first production iOS UI for sync status + insight visibility, with deterministic state mapping tests.
+
+Notes
+- Replaced placeholder `ContentView` with a dashboard showing sync freshness, delta window, export footprint, and anchor status.
+- Added Sync Details view for run metadata (run id, file counts/paths, row counts) without raw PHI text.
+- Added `SyncStatusStore` enrichment to compute deterministic delta windows from NDJSON timestamps.
+- Added `InsightsStore` to load share-safe Doctor's Note and Summary cards with disclaimer + freshness labels.
+- Added unit tests for snapshot formatting/state mapping and insight card extraction behavior.
+
+Local verification
+- Not run locally: iOS SwiftUI/HealthKit tests require macOS/Xcode runner.

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -95,3 +95,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,128,UNASSIGNED,45,codex,UNASSIGNED,"Blocking CI safety guardrails for PHI patterns and output disclaimer/citation contracts"
 2026-02-02,92,UNASSIGNED,35,codex,UNASSIGNED,"CI governance artifact report for deterministic issue-discipline evidence"
 2026-02-02,72,UNASSIGNED,30,codex,UNASSIGNED,"Plan refresh and deterministic CI issue-reference gate coverage tests"
+2026-02-02,159,UNASSIGNED,75,codex,UNASSIGNED,"iOS sync status dashboard + insights cards + deterministic mapping tests"

--- a/ios/HealthDelta/Sources/ContentView.swift
+++ b/ios/HealthDelta/Sources/ContentView.swift
@@ -1,18 +1,159 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var viewModel = DashboardViewModel()
+
     var body: some View {
-        VStack(spacing: 12) {
-            Text("HealthDelta")
-                .font(.title)
-            Text("CI bootstrap build")
-                .font(.subheadline)
+        NavigationStack {
+            List {
+                Section("Sync Status") {
+                    if let sync = viewModel.syncSnapshot {
+                        LabeledContent("Last sync", value: sync.lastSyncLabel + " UTC")
+                        LabeledContent("Last delta window", value: sync.lastDeltaLabel + (sync.deltaStart == nil ? "" : " UTC"))
+                        LabeledContent("Rows exported", value: sync.totalRowsLabel)
+                        LabeledContent("Bytes exported", value: sync.totalBytesLabel)
+                        LabeledContent("Anchor status", value: sync.anchorStatusLabel)
+                        NavigationLink("View sync details") {
+                            SyncDetailsView(snapshot: sync)
+                        }
+                    } else {
+                        Text("No sync data yet.")
+                            .font(.headline)
+                        Text("Run an iOS export first. Then pull outputs into the operator pipeline to unlock insights.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("Insights") {
+                    if viewModel.insightCards.isEmpty {
+                        Text("No insights available yet.")
+                            .font(.headline)
+                        Text("After your first completed run, this screen will show Doctor's Note and summary cards with freshness details.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(viewModel.insightCards) { card in
+                            InsightCardView(card: card)
+                        }
+                    }
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Section("Needs attention") {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("HealthDelta")
+            .toolbar {
+                Button("Refresh") {
+                    viewModel.refresh()
+                }
+            }
+            .task {
+                viewModel.refresh()
+            }
         }
-        .padding()
     }
 }
 
-#Preview {
-    ContentView()
+private struct SyncDetailsView: View {
+    let snapshot: SyncStatusSnapshot
+
+    var body: some View {
+        List {
+            Section("Run") {
+                LabeledContent("Run ID", value: snapshot.runID)
+                LabeledContent("Generated", value: snapshot.lastSyncLabel + " UTC")
+                LabeledContent("Source files", value: "\(snapshot.fileCount)")
+                LabeledContent("Rows", value: snapshot.totalRowsLabel)
+                LabeledContent("Bytes", value: snapshot.totalBytesLabel)
+                LabeledContent("Anchors", value: "\(snapshot.anchorFiles)")
+            }
+
+            Section("Row Counts") {
+                if snapshot.rowCounts.isEmpty {
+                    Text("No row counts found in manifest.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(snapshot.rowCounts.keys.sorted(), id: \.self) { key in
+                        LabeledContent(key, value: "\(snapshot.rowCounts[key] ?? 0)")
+                    }
+                }
+            }
+
+            Section("Source Paths") {
+                if snapshot.sourceFiles.isEmpty {
+                    Text("No source file entries in manifest.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(snapshot.sourceFiles, id: \.self) { path in
+                        Text(path)
+                            .font(.footnote.monospaced())
+                    }
+                }
+            }
+        }
+        .navigationTitle("Sync Details")
+    }
 }
 
+private struct InsightCardView: View {
+    let card: InsightCard
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(card.title)
+                .font(.headline)
+            Text(card.freshnessLabel)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(card.body)
+                .font(.body)
+                .lineLimit(8)
+            Text(card.disclaimer)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("Source: \(card.sourceLabel)")
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+@MainActor
+final class DashboardViewModel: ObservableObject {
+    @Published var syncSnapshot: SyncStatusSnapshot?
+    @Published var insightCards: [InsightCard] = []
+    @Published var errorMessage: String?
+
+    private let syncStore: SyncStatusStore
+    private let insightsStore: InsightsStore
+
+    init(
+        syncStore: SyncStatusStore = SyncStatusStore(),
+        insightsStore: InsightsStore = InsightsStore()
+    ) {
+        self.syncStore = syncStore
+        self.insightsStore = insightsStore
+    }
+
+    func refresh() {
+        do {
+            syncSnapshot = try syncStore.loadLatest()
+            insightCards = try insightsStore.loadLatestCards()
+            errorMessage = nil
+        } catch SyncStatusStore.LoadError.noRunDirectory {
+            syncSnapshot = nil
+            insightCards = []
+            errorMessage = nil
+        } catch {
+            syncSnapshot = nil
+            insightCards = []
+            errorMessage = "Unable to load local run data. \(error.localizedDescription)"
+        }
+    }
+}

--- a/ios/HealthDelta/Sources/InsightsStore.swift
+++ b/ios/HealthDelta/Sources/InsightsStore.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+struct InsightCard: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let body: String
+    let disclaimer: String
+    let sourceLabel: String
+    let freshnessLabel: String
+}
+
+struct InsightsStore {
+    private let fileManager: FileManager
+    private let appDocumentsURL: URL
+
+    init(
+        fileManager: FileManager = .default,
+        appDocumentsURL: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        self.appDocumentsURL = appDocumentsURL ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+    }
+
+    func loadLatestCards() throws -> [InsightCard] {
+        let root = appDocumentsURL.appendingPathComponent("HealthDelta", isDirectory: true)
+        guard let runDirectory = try latestRunDirectory(root: root) else {
+            return []
+        }
+
+        var cards: [InsightCard] = []
+        let runID = runDirectory.lastPathComponent
+
+        if let noteCard = loadCard(
+            fileURL: runDirectory.appendingPathComponent("note/doctor_note.md", isDirectory: false),
+            title: "Doctor's Note",
+            sourceLabel: "note/doctor_note.md",
+            fallbackBody: "Your next sync will generate a one-screen summary of trends and risk flags.",
+            runID: runID
+        ) {
+            cards.append(noteCard)
+        }
+
+        if let reportCard = loadCard(
+            fileURL: runDirectory.appendingPathComponent("reports/summary.md", isDirectory: false),
+            title: "Summary",
+            sourceLabel: "reports/summary.md",
+            fallbackBody: "Summary data appears after a completed operator run.",
+            runID: runID
+        ) {
+            cards.append(reportCard)
+        }
+
+        return cards
+    }
+
+    private func loadCard(
+        fileURL: URL,
+        title: String,
+        sourceLabel: String,
+        fallbackBody: String,
+        runID: String
+    ) -> InsightCard? {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
+        let bodyText = (try? String(contentsOf: fileURL, encoding: .utf8))
+            .map { normalizeBody($0, fallback: fallbackBody) }
+            ?? fallbackBody
+        let modified = (try? fileManager.attributesOfItem(atPath: fileURL.path)[.modificationDate]) as? Date
+        let freshness = modified.map { SyncStatusStore.dateFormatter.string(from: $0) } ?? "Unknown"
+
+        return InsightCard(
+            id: "\(runID)-\(sourceLabel)",
+            title: title,
+            body: bodyText,
+            disclaimer: "For education only. This is not medical advice.",
+            sourceLabel: sourceLabel,
+            freshnessLabel: "Updated \(freshness) UTC"
+        )
+    }
+
+    private func normalizeBody(_ raw: String, fallback: String) -> String {
+        let cleaned = raw
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.isEmpty {
+            return fallback
+        }
+        return cleaned
+    }
+
+    private func latestRunDirectory(root: URL) throws -> URL? {
+        guard fileManager.fileExists(atPath: root.path) else {
+            return nil
+        }
+        let candidates = try fileManager.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        let runDirs = candidates.filter { url in
+            var isDir: ObjCBool = false
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
+                return false
+            }
+            return fileManager.fileExists(atPath: url.appendingPathComponent("manifest.json").path)
+        }
+        return runDirs.max { lhs, rhs in
+            let la = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+            let ra = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+            return la < ra
+        }
+    }
+}

--- a/ios/HealthDelta/Sources/SyncStatusStore.swift
+++ b/ios/HealthDelta/Sources/SyncStatusStore.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+struct SyncStatusSnapshot: Equatable {
+    let runID: String
+    let generatedAt: Date?
+    let deltaStart: Date?
+    let deltaEnd: Date?
+    let totalRows: Int
+    let totalBytes: Int
+    let fileCount: Int
+    let anchorFiles: Int
+    let rowCounts: [String: Int]
+    let sourceFiles: [String]
+
+    var hasData: Bool {
+        totalRows > 0 || fileCount > 0
+    }
+
+    var lastSyncLabel: String {
+        guard let generatedAt else { return "Unknown" }
+        return SyncStatusStore.dateFormatter.string(from: generatedAt)
+    }
+
+    var lastDeltaLabel: String {
+        guard let deltaStart, let deltaEnd else { return "Not available yet" }
+        return "\(SyncStatusStore.dateFormatter.string(from: deltaStart)) -> \(SyncStatusStore.dateFormatter.string(from: deltaEnd))"
+    }
+
+    var anchorStatusLabel: String {
+        if anchorFiles == 0 {
+            return "No anchors saved yet"
+        }
+        let files = SyncStatusStore.numberFormatter.string(from: NSNumber(value: anchorFiles)) ?? "\(anchorFiles)"
+        return "Anchors active (\(files) files)"
+    }
+
+    var totalRowsLabel: String {
+        SyncStatusStore.numberFormatter.string(from: NSNumber(value: totalRows)) ?? "\(totalRows)"
+    }
+
+    var totalBytesLabel: String {
+        ByteCountFormatter.string(fromByteCount: Int64(totalBytes), countStyle: .file)
+    }
+}
+
+struct SyncStatusStore {
+    enum LoadError: Error, Equatable {
+        case noRunDirectory
+        case malformedManifest
+    }
+
+    private let fileManager: FileManager
+    private let appDocumentsURL: URL
+    private let appSupportURL: URL
+
+    init(
+        fileManager: FileManager = .default,
+        appDocumentsURL: URL? = nil,
+        appSupportURL: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        self.appDocumentsURL = appDocumentsURL ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        self.appSupportURL = appSupportURL ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    }
+
+    static let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        return f
+    }()
+
+    static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+
+    private static let iso8601WithFractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let iso8601NoFractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    func loadLatest() throws -> SyncStatusSnapshot {
+        let healthDeltaRoot = appDocumentsURL.appendingPathComponent("HealthDelta", isDirectory: true)
+        guard let runDirectory = try latestRunDirectory(root: healthDeltaRoot) else {
+            throw LoadError.noRunDirectory
+        }
+
+        let manifestURL = runDirectory.appendingPathComponent("manifest.json", isDirectory: false)
+        let data = try Data(contentsOf: manifestURL)
+        let object = try JSONSerialization.jsonObject(with: data, options: [])
+        guard let manifest = object as? [String: Any] else {
+            throw LoadError.malformedManifest
+        }
+
+        let runID = (manifest["run_id"] as? String) ?? runDirectory.lastPathComponent
+        let files = (manifest["files"] as? [[String: Any]]) ?? []
+        let rowCounts = (manifest["row_counts"] as? [String: Any]) ?? [:]
+
+        var totalBytes = 0
+        var sourceFiles: [String] = []
+        for file in files {
+            if let x = file["size_bytes"] as? Int {
+                totalBytes += x
+            }
+            if let p = file["path"] as? String {
+                sourceFiles.append(p)
+            }
+        }
+
+        var normalizedRowCounts: [String: Int] = [:]
+        for (k, v) in rowCounts.sorted(by: { $0.key < $1.key }) {
+            if let i = v as? Int {
+                normalizedRowCounts[k] = i
+            }
+        }
+        let totalRows = normalizedRowCounts.values.reduce(0, +)
+        let (deltaStart, deltaEnd) = deltaWindow(runDirectory: runDirectory, files: files)
+
+        let attrs = try? fileManager.attributesOfItem(atPath: manifestURL.path)
+        let generatedAt = attrs?[.modificationDate] as? Date
+
+        let anchorsDir = appSupportURL.appendingPathComponent("HealthDelta/anchors", isDirectory: true)
+        let anchorFiles: Int
+        if let list = try? fileManager.contentsOfDirectory(at: anchorsDir, includingPropertiesForKeys: nil) {
+            anchorFiles = list.filter { !$0.hasDirectoryPath }.count
+        } else {
+            anchorFiles = 0
+        }
+
+        return SyncStatusSnapshot(
+            runID: runID,
+            generatedAt: generatedAt,
+            deltaStart: deltaStart,
+            deltaEnd: deltaEnd,
+            totalRows: totalRows,
+            totalBytes: totalBytes,
+            fileCount: files.count,
+            anchorFiles: anchorFiles,
+            rowCounts: normalizedRowCounts,
+            sourceFiles: sourceFiles.sorted()
+        )
+    }
+
+    private func latestRunDirectory(root: URL) throws -> URL? {
+        guard fileManager.fileExists(atPath: root.path) else {
+            return nil
+        }
+        let candidates = try fileManager.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        let runDirs = candidates.filter { url in
+            var isDir: ObjCBool = false
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
+                return false
+            }
+            return fileManager.fileExists(atPath: url.appendingPathComponent("manifest.json").path)
+        }
+        return runDirs.max { lhs, rhs in
+            let la = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+            let ra = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+            return la < ra
+        }
+    }
+
+    private func deltaWindow(runDirectory: URL, files: [[String: Any]]) -> (Date?, Date?) {
+        var minStart: Date?
+        var maxEnd: Date?
+
+        for file in files {
+            guard let path = file["path"] as? String, path.hasSuffix(".ndjson") else {
+                continue
+            }
+            let ndjsonURL = runDirectory.appendingPathComponent(path, isDirectory: false)
+            guard let text = try? String(contentsOf: ndjsonURL, encoding: .utf8) else {
+                continue
+            }
+
+            for rawLine in text.split(separator: "\n") {
+                let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !line.isEmpty, let data = line.data(using: .utf8) else {
+                    continue
+                }
+                guard
+                    let object = try? JSONSerialization.jsonObject(with: data, options: []),
+                    let row = object as? [String: Any]
+                else {
+                    continue
+                }
+
+                if let value = row["start_time"] as? String, let parsed = parseISO8601(value) {
+                    minStart = min(minStart ?? parsed, parsed)
+                }
+                if let value = row["end_time"] as? String, let parsed = parseISO8601(value) {
+                    maxEnd = max(maxEnd ?? parsed, parsed)
+                }
+            }
+        }
+
+        return (minStart, maxEnd)
+    }
+
+    private func parseISO8601(_ value: String) -> Date? {
+        if let d = Self.iso8601WithFractional.date(from: value) {
+            return d
+        }
+        return Self.iso8601NoFractional.date(from: value)
+    }
+}

--- a/ios/HealthDelta/Tests/InsightsStoreTests.swift
+++ b/ios/HealthDelta/Tests/InsightsStoreTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+
+@testable import HealthDelta
+
+final class InsightsStoreTests: XCTestCase {
+    func testLoadLatestCardsReturnsDoctorNoteAndSummaryWithFreshness() throws {
+        let fixture = try FixtureDocs()
+        let runDir = fixture.documents.appendingPathComponent("HealthDelta/run_20260202_010203", isDirectory: true)
+        try FileManager.default.createDirectory(at: runDir.appendingPathComponent("note", isDirectory: true), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: runDir.appendingPathComponent("reports", isDirectory: true), withIntermediateDirectories: true)
+
+        try "{}".write(to: runDir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
+        try "# Doctor Note\n- Trend improving".write(
+            to: runDir.appendingPathComponent("note/doctor_note.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "# Summary\n- Keep walking daily".write(
+            to: runDir.appendingPathComponent("reports/summary.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let modified = Date(timeIntervalSince1970: 1_706_884_800)
+        try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: runDir.appendingPathComponent("note/doctor_note.md").path)
+        try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: runDir.appendingPathComponent("reports/summary.md").path)
+
+        let store = InsightsStore(fileManager: .default, appDocumentsURL: fixture.documents)
+        let cards = try store.loadLatestCards()
+
+        XCTAssertEqual(cards.count, 2)
+        XCTAssertEqual(cards.map(\.title), ["Doctor's Note", "Summary"])
+        XCTAssertTrue(cards.allSatisfy { $0.disclaimer.contains("not medical advice") })
+        XCTAssertEqual(cards[0].sourceLabel, "note/doctor_note.md")
+        XCTAssertEqual(cards[1].sourceLabel, "reports/summary.md")
+        XCTAssertTrue(cards.allSatisfy { $0.freshnessLabel.contains("2024") })
+    }
+
+    func testLoadLatestCardsReturnsEmptyWhenNoArtifactsExist() throws {
+        let fixture = try FixtureDocs()
+        let runDir = fixture.documents.appendingPathComponent("HealthDelta/run_20260202_010203", isDirectory: true)
+        try FileManager.default.createDirectory(at: runDir, withIntermediateDirectories: true)
+        try "{}".write(to: runDir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
+
+        let store = InsightsStore(fileManager: .default, appDocumentsURL: fixture.documents)
+        XCTAssertEqual(try store.loadLatestCards(), [])
+    }
+}
+
+private struct FixtureDocs {
+    let root: URL
+    let documents: URL
+
+    init() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("HealthDeltaInsightsTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        documents = root.appendingPathComponent("Documents", isDirectory: true)
+        try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+    }
+}

--- a/ios/HealthDelta/Tests/SyncStatusStoreTests.swift
+++ b/ios/HealthDelta/Tests/SyncStatusStoreTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import XCTest
+
+@testable import HealthDelta
+
+final class SyncStatusStoreTests: XCTestCase {
+    func testLoadLatestBuildsDeterministicSnapshot() throws {
+        let fixture = try FixtureDirs()
+        let runDir = fixture.documents.appendingPathComponent("HealthDelta/run_20260202_010203", isDirectory: true)
+        try FileManager.default.createDirectory(at: runDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: runDir.appendingPathComponent("ndjson", isDirectory: true), withIntermediateDirectories: true)
+
+        let manifest = """
+        {"files":[{"path":"ndjson/observations.ndjson","sha256":"x","size_bytes":1250}],"row_counts":{"observations":2},"run_id":"run_20260202_010203"}
+        """
+        try manifest.write(to: runDir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
+
+        let ndjson = """
+        {"start_time":"2026-02-01T00:00:00.000Z","end_time":"2026-02-01T01:00:00.000Z"}
+        {"start_time":"2026-02-01T05:00:00.000Z","end_time":"2026-02-01T08:30:00.000Z"}
+        """
+        try ndjson.write(to: runDir.appendingPathComponent("ndjson/observations.ndjson"), atomically: true, encoding: .utf8)
+
+        let manifestDate = Date(timeIntervalSince1970: 1_706_884_800) // 2024-02-01T00:00:00Z
+        try FileManager.default.setAttributes([.modificationDate: manifestDate], ofItemAtPath: runDir.appendingPathComponent("manifest.json").path)
+
+        let anchorDir = fixture.appSupport.appendingPathComponent("HealthDelta/anchors", isDirectory: true)
+        try FileManager.default.createDirectory(at: anchorDir, withIntermediateDirectories: true)
+        try "anchor".write(to: anchorDir.appendingPathComponent("steps.anchor"), atomically: true, encoding: .utf8)
+
+        let store = SyncStatusStore(
+            fileManager: .default,
+            appDocumentsURL: fixture.documents,
+            appSupportURL: fixture.appSupport
+        )
+        let snapshot = try store.loadLatest()
+
+        XCTAssertEqual(snapshot.runID, "run_20260202_010203")
+        XCTAssertEqual(snapshot.totalRows, 2)
+        XCTAssertEqual(snapshot.totalRowsLabel, "2")
+        XCTAssertEqual(snapshot.totalBytes, 1250)
+        XCTAssertEqual(snapshot.fileCount, 1)
+        XCTAssertEqual(snapshot.anchorFiles, 1)
+        XCTAssertEqual(snapshot.rowCounts, ["observations": 2])
+        XCTAssertEqual(snapshot.sourceFiles, ["ndjson/observations.ndjson"])
+        XCTAssertTrue(snapshot.lastSyncLabel.contains("2024"))
+        XCTAssertTrue(snapshot.lastSyncLabel.contains("12:00 AM"))
+        XCTAssertTrue(snapshot.lastDeltaLabel.contains("2026"))
+        XCTAssertTrue(snapshot.lastDeltaLabel.contains("8:30 AM"))
+    }
+
+    func testLoadLatestThrowsWhenNoRunDirectoryExists() throws {
+        let fixture = try FixtureDirs()
+        let store = SyncStatusStore(
+            fileManager: .default,
+            appDocumentsURL: fixture.documents,
+            appSupportURL: fixture.appSupport
+        )
+
+        XCTAssertThrowsError(try store.loadLatest()) { error in
+            XCTAssertEqual(error as? SyncStatusStore.LoadError, .noRunDirectory)
+        }
+    }
+}
+
+private struct FixtureDirs {
+    let root: URL
+    let documents: URL
+    let appSupport: URL
+
+    init() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("HealthDeltaSyncStatusTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        documents = root.appendingPathComponent("Documents", isDirectory: true)
+        appSupport = root.appendingPathComponent("ApplicationSupport", isDirectory: true)
+        try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+    }
+}


### PR DESCRIPTION
## What
- replace the iOS placeholder screen with a dashboard that surfaces local sync status (last sync time, delta window, rows, bytes, anchor status)
- add a Sync Details view showing deterministic run metadata (run id, row counts, source files, anchors)
- add Insights loading for share-safe artifacts (, ) with freshness + disclaimer context
- add empty-state guidance for first-run users (no dead-ends)
- add iOS unit tests for sync snapshot mapping and insight card mapping
- add required audit artifacts for issue #159 (, , )

## Why
Closes the current gap between backend/operator readiness and in-app user visibility so users can trust sync state and read share-safe health insights.

## Verification
- 
- iOS unit tests are included and should run in macOS CI runner:
  - 
  - 

Closes #159