### PR TITLE
Issue: #162 - ORIN benchmark artifacts and regression thresholds

### DIFF
--- a/.ai/prompts/issue_162.md
+++ b/.ai/prompts/issue_162.md
@@ -1,0 +1,16 @@
+# Issue #162 Prompt (Immutable)
+
+Implement ORIN backend benchmark artifacts and regression threshold enforcement.
+
+Scope:
+- Add a dedicated ORIN benchmark workflow that runs on labels `[self-hosted, linux, orin]`.
+- Collect deterministic benchmark metrics for backend `/summary`, `/qa`, and CLI pipeline run timings.
+- Persist machine-readable JSON and operator-facing Markdown artifacts.
+- Add threshold enforcement with explicit metric/threshold/observed failure messages.
+- Document workflow usage, threshold location, and local reproduction in ORIN deployment runbook.
+- Add unit tests for threshold checker logic.
+
+Constraints:
+- Synthetic/share-safe inputs only.
+- No new governance rules.
+- Keep implementation bounded to benchmark proof + threshold guardrails.

--- a/.ai/sessions/2026-02-02/session_16.md
+++ b/.ai/sessions/2026-02-02/session_16.md
@@ -1,0 +1,18 @@
+# Session 16 - 2026-02-02
+
+Issue: #162
+
+Goal
+- Add ORIN benchmark workflow + threshold regression guardrails with reproducible artifacts.
+
+Notes
+- Added ORIN benchmark workflow (`orin_backend_benchmark.yml`) with artifact upload.
+- Added benchmark runner script to measure `/summary`, `/qa`, and pipeline runtimes.
+- Added threshold gate script with explicit metric/threshold/observed diagnostics.
+- Added threshold config in `deploy/orin/benchmark_thresholds.json`.
+- Updated ORIN runbook and plan references for active Issue #162 work.
+- Added unit tests for threshold checker behavior.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_orin_benchmark_thresholds.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -99,3 +99,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,159,UNASSIGNED,20,codex,UNASSIGNED,"Fix brittle iOS time-label assertions in SyncStatusStoreTests after macOS CI failure"
 2026-02-02,159,UNASSIGNED,15,codex,UNASSIGNED,"Fix optional+accuracy compile issue in SyncStatusStoreTests on macOS CI"
 2026-02-02,159,UNASSIGNED,10,codex,UNASSIGNED,"Correct delta epoch expectations in SyncStatusStoreTests from macOS CI evidence"
+2026-02-02,162,UNASSIGNED,70,codex,UNASSIGNED,"ORIN benchmark workflow + threshold checker + runbook integration"

--- a/.github/workflows/orin_backend_benchmark.yml
+++ b/.github/workflows/orin_backend_benchmark.yml
@@ -1,0 +1,77 @@
+name: ORIN Backend Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Backend base URL on ORIN
+        required: true
+        default: http://127.0.0.1:8080
+        type: string
+      summary_input_path:
+        description: Input path visible inside backend container for /summary and /qa
+        required: true
+        default: /app/deploy/fixtures/profile_export
+        type: string
+      pipeline_input_path:
+        description: Host path used for CLI pipeline benchmark
+        required: true
+        default: tests/fixtures/profile_export
+        type: string
+      iterations:
+        description: Summary/QA iteration count
+        required: true
+        default: "5"
+        type: string
+      pipeline_iterations:
+        description: Pipeline run iteration count
+        required: true
+        default: "3"
+        type: string
+
+concurrency:
+  group: orin-backend-benchmark
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: ORIN benchmark + threshold gate
+    runs-on: [self-hosted, linux, orin]
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run ORIN benchmark
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/orin-benchmark
+          python3 scripts/cd/orin_benchmark_backend.py \
+            --base-url "${{ inputs.base_url }}" \
+            --summary-input-path "${{ inputs.summary_input_path }}" \
+            --pipeline-input-path "${{ inputs.pipeline_input_path }}" \
+            --iterations "${{ inputs.iterations }}" \
+            --pipeline-iterations "${{ inputs.pipeline_iterations }}" \
+            --out-json artifacts/orin-benchmark/benchmark_results.json \
+            --out-md artifacts/orin-benchmark/benchmark_report.md
+
+      - name: Enforce regression thresholds
+        run: |
+          set -euo pipefail
+          python3 scripts/cd/check_benchmark_thresholds.py \
+            --results artifacts/orin-benchmark/benchmark_results.json \
+            --thresholds deploy/orin/benchmark_thresholds.json
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: orin-backend-benchmark
+          path: |
+            artifacts/orin-benchmark/benchmark_results.json
+            artifacts/orin-benchmark/benchmark_report.md
+          if-no-files-found: error

--- a/deploy/orin/benchmark_thresholds.json
+++ b/deploy/orin/benchmark_thresholds.json
@@ -1,0 +1,19 @@
+{
+  "metrics": {
+    "summary.p95_ms": {
+      "max": 12000.0
+    },
+    "summary.p50_ms": {
+      "max": 6000.0
+    },
+    "qa.p95_ms": {
+      "max": 12000.0
+    },
+    "qa.p50_ms": {
+      "max": 7000.0
+    },
+    "pipeline.p95_s": {
+      "max": 45.0
+    }
+  }
+}

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -46,8 +46,8 @@ Completed
 - Issues #1-#86 are closed (bootstrap through governance/evidence guardrails for FHIR, NDJSON, reporting, and CI policy enforcement).
 - Issue #117 is closed (managed hidden worktree root + auto-prune + CI path guardrail).
 
-Active governance carryover
-1) Issue #72 - Governance: plan refresh + CI issue reference gate (active)
+Governance carryover
+1) Issue #72 - Governance: plan refresh + CI issue reference gate (closed)
    - https://github.com/dave0875/HealthDelta/issues/72
 2) Issue #92 - Governance: CI guardrails for issue discipline (closed)
    - https://github.com/dave0875/HealthDelta/issues/92
@@ -71,9 +71,11 @@ New planning phase: Orin production deployment target (`orin.local`)
     - https://github.com/dave0875/HealthDelta/issues/127
 11) Issue #128 - Orin MMF: CI safety guardrails for PHI leakage + disclosure requirements (closed)
     - https://github.com/dave0875/HealthDelta/issues/128
+12) Issue #162 - ORIN benchmark artifacts + regression thresholds (active)
+    - https://github.com/dave0875/HealthDelta/issues/162
 
 Next roadmap focus (post-MMF)
-- Harden performance envelopes on ORIN with benchmark artifacts and regression thresholds.
+- Complete Issue #162 benchmark rollout and establish baseline threshold maintenance cadence.
 - Expand risk/trend rule coverage with stricter clinical evidence mappings.
 - Add operator-facing runbook automation for routine rollback drills and release readiness checks.
 

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -8,6 +8,21 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
 - Runner: ORIN self-hosted GitHub Actions runner (LAN-local)
 - Deploy dir: `/opt/healthdelta`
 
+## Benchmark workflow (Issue #162)
+- Workflow: `.github/workflows/orin_backend_benchmark.yml`
+- Trigger: manual dispatch (`workflow_dispatch`)
+- Runner: ORIN self-hosted GitHub Actions runner (`self-hosted`, `linux`, `orin`)
+- Inputs:
+  - `base_url` (default `http://127.0.0.1:8080`)
+  - `summary_input_path` (default `/app/deploy/fixtures/profile_export`)
+  - `pipeline_input_path` (default `tests/fixtures/profile_export`)
+  - `iterations` and `pipeline_iterations`
+- Output artifact: `orin-backend-benchmark`
+  - `benchmark_results.json` (machine-readable metrics)
+  - `benchmark_report.md` (operator-readable summary)
+- Regression policy thresholds are defined in `deploy/orin/benchmark_thresholds.json`.
+- CI fails with explicit metric diagnostics when observed values exceed thresholds.
+
 ## Planning artifact linkage
 - Model/runtime planning matrix for ORIN MMF workloads: `docs/orin_model_runtime_matrix.md` (Issue #122).
 - This matrix is the source for summary/risk/trend/Q&A runtime selection and latency/memory envelopes.
@@ -73,6 +88,13 @@ The deploy workflow verifies:
   - `artifacts/linux/backend_slice/smoke.log`
   - `artifacts/linux/backend_slice/summary_response.json`
 
+Benchmark verification adds:
+- p50/p95 latency metrics for `POST /summary` and `POST /qa`
+- p50/p95 runtime metrics for `healthdelta pipeline run` on synthetic fixture input
+- threshold enforcement messages in the form:
+  - `metric=<name> threshold<= <value> observed= <value>`
+  - This enables deterministic pass/fail debugging without reading raw logs.
+
 ## Grounded Q&A endpoint (Issue #126)
 - Endpoint: `POST /qa`
 - Required request fields:
@@ -101,3 +123,21 @@ This script:
 ## Credentials / secrets
 - The workflow uses `GITHUB_TOKEN` for `docker login ghcr.io` with `packages: read` permission.
 - If GHCR pulls fail on ORIN, use a fine-grained PAT with `read:packages` via a new secret and update the workflow accordingly (do not commit tokens).
+
+## Local reproduction (on ORIN runner host)
+Run benchmark + threshold check without GitHub Actions:
+
+```bash
+python3 scripts/cd/orin_benchmark_backend.py \
+  --base-url http://127.0.0.1:8080 \
+  --summary-input-path /app/deploy/fixtures/profile_export \
+  --pipeline-input-path tests/fixtures/profile_export \
+  --iterations 5 \
+  --pipeline-iterations 3 \
+  --out-json artifacts/orin-benchmark/benchmark_results.json \
+  --out-md artifacts/orin-benchmark/benchmark_report.md
+
+python3 scripts/cd/check_benchmark_thresholds.py \
+  --results artifacts/orin-benchmark/benchmark_results.json \
+  --thresholds deploy/orin/benchmark_thresholds.json
+```

--- a/scripts/cd/check_benchmark_thresholds.py
+++ b/scripts/cd/check_benchmark_thresholds.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _extract_metric(results: dict[str, Any], key: str) -> float:
+    root: Any = results
+    for part in key.split("."):
+        if not isinstance(root, dict) or part not in root:
+            raise KeyError(key)
+        root = root[part]
+    if not isinstance(root, (int, float)):
+        raise TypeError(f"{key} is not numeric")
+    return float(root)
+
+
+def _args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Validate ORIN benchmark results against thresholds.")
+    p.add_argument("--results", required=True, help="Path to benchmark results JSON")
+    p.add_argument("--thresholds", required=True, help="Path to threshold JSON")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _args()
+    results = json.loads(Path(args.results).read_text(encoding="utf-8"))
+    thresholds = json.loads(Path(args.thresholds).read_text(encoding="utf-8"))
+    metrics = thresholds.get("metrics")
+    if not isinstance(metrics, dict):
+        raise SystemExit("thresholds missing object: metrics")
+
+    failures: list[str] = []
+    for key in sorted(metrics.keys()):
+        policy = metrics[key]
+        if not isinstance(policy, dict):
+            failures.append(f"metric={key} threshold policy is not an object")
+            continue
+        try:
+            observed = _extract_metric(results, f"metrics.{key}")
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"metric={key} missing in results ({exc})")
+            continue
+
+        max_value = policy.get("max")
+        min_value = policy.get("min")
+        if isinstance(max_value, (int, float)) and observed > float(max_value):
+            failures.append(
+                f"metric={key} threshold<= {float(max_value):.4f} observed= {observed:.4f} (regression above max)"
+            )
+        if isinstance(min_value, (int, float)) and observed < float(min_value):
+            failures.append(
+                f"metric={key} threshold>= {float(min_value):.4f} observed= {observed:.4f} (regression below min)"
+            )
+
+    if failures:
+        print("policy failure: benchmark regression threshold check failed.")
+        for line in failures:
+            print(f"- {line}")
+        print("how to fix: optimize runtime or adjust thresholds in deploy/orin/benchmark_thresholds.json with issue-backed rationale.")
+        return 1
+
+    print("benchmark threshold check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cd/orin_benchmark_backend.py
+++ b/scripts/cd/orin_benchmark_backend.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from statistics import median
+from typing import Any
+from urllib.request import Request, urlopen
+
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        raise ValueError("cannot compute percentile of empty set")
+    if len(values) == 1:
+        return values[0]
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * p
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = rank - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def _post_json(base_url: str, path: str, payload: dict[str, Any]) -> tuple[dict[str, Any], float]:
+    body = json.dumps(payload, sort_keys=True).encode("utf-8")
+    req = Request(
+        base_url.rstrip("/") + path,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    start = time.perf_counter()
+    with urlopen(req) as resp:
+        data = resp.read().decode("utf-8")
+        status = resp.status
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    if status != 200:
+        raise RuntimeError(f"{path} returned unexpected status: {status}")
+    obj = json.loads(data)
+    if not isinstance(obj, dict):
+        raise RuntimeError(f"{path} payload was not a JSON object")
+    return obj, elapsed_ms
+
+
+def _validate_summary_shape(payload: dict[str, Any]) -> None:
+    if not isinstance(payload.get("summary"), str):
+        raise RuntimeError("summary endpoint missing string 'summary'")
+    if not isinstance(payload.get("citations"), list) or not payload["citations"]:
+        raise RuntimeError("summary endpoint missing non-empty 'citations'")
+    if not isinstance(payload.get("risk_flags"), dict):
+        raise RuntimeError("summary endpoint missing 'risk_flags'")
+
+
+def _validate_qa_shape(payload: dict[str, Any]) -> None:
+    qa = payload.get("qa")
+    if not isinstance(qa, dict):
+        raise RuntimeError("qa endpoint missing 'qa' object")
+    if not isinstance(qa.get("citations"), list) or not qa["citations"]:
+        raise RuntimeError("qa endpoint missing non-empty citations")
+    disclaimer = qa.get("disclaimer")
+    if not isinstance(disclaimer, str) or "not medical advice" not in disclaimer.lower():
+        raise RuntimeError("qa endpoint missing required disclaimer")
+
+
+def _stats(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    return {
+        "count": float(len(ordered)),
+        "min": ordered[0],
+        "max": ordered[-1],
+        "p50": float(median(ordered)),
+        "p95": float(_percentile(ordered, 0.95)),
+    }
+
+
+def _run_pipeline_once(input_path: str, out_dir: Path) -> float:
+    out_dir.parent.mkdir(parents=True, exist_ok=True)
+    start = time.perf_counter()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "healthdelta.cli",
+            "pipeline",
+            "run",
+            "--input",
+            input_path,
+            "--out",
+            str(out_dir),
+            "--mode",
+            "share",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed_s = time.perf_counter() - start
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "pipeline run failed: " + (proc.stderr.strip() or proc.stdout.strip() or f"exit={proc.returncode}")
+        )
+    return elapsed_s
+
+
+def _write_markdown(path: Path, data: dict[str, Any]) -> None:
+    lines: list[str] = []
+    lines.append("# ORIN Backend Benchmark Report")
+    lines.append("")
+    lines.append(f"- timestamp_utc: `{data['timestamp_utc']}`")
+    lines.append(f"- base_url: `{data['base_url']}`")
+    lines.append(f"- summary_input_path: `{data['summary_input_path']}`")
+    lines.append(f"- pipeline_input_path: `{data['pipeline_input_path']}`")
+    lines.append("")
+    lines.append("## Endpoint latency (ms)")
+    for endpoint in ("summary", "qa"):
+        s = data["metrics"][endpoint]
+        lines.append(
+            f"- {endpoint}: p50={s['p50_ms']:.2f}, p95={s['p95_ms']:.2f}, min={s['min_ms']:.2f}, max={s['max_ms']:.2f}, n={s['count']}"
+        )
+    lines.append("")
+    lines.append("## Pipeline runtime (s)")
+    ps = data["metrics"]["pipeline"]
+    lines.append(
+        f"- pipeline run: p50={ps['p50_s']:.2f}, p95={ps['p95_s']:.2f}, min={ps['min_s']:.2f}, max={ps['max_s']:.2f}, n={ps['count']}"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run ORIN backend benchmark and emit deterministic artifacts.")
+    p.add_argument("--base-url", default="http://127.0.0.1:8080")
+    p.add_argument("--summary-input-path", default="/app/deploy/fixtures/profile_export")
+    p.add_argument("--pipeline-input-path", default="tests/fixtures/profile_export")
+    p.add_argument("--iterations", type=int, default=5)
+    p.add_argument("--pipeline-iterations", type=int, default=3)
+    p.add_argument("--pipeline-out", default="artifacts/orin-benchmark/pipeline_runs")
+    p.add_argument("--out-json", required=True)
+    p.add_argument("--out-md", required=True)
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _args()
+    if args.iterations < 1 or args.pipeline_iterations < 1:
+        raise SystemExit("iterations and pipeline-iterations must be >= 1")
+
+    summary_latencies: list[float] = []
+    qa_latencies: list[float] = []
+    pipeline_times: list[float] = []
+
+    for _ in range(args.iterations):
+        summary_payload = {"input_path": args.summary_input_path, "citation_limit": 5}
+        summary_obj, summary_ms = _post_json(args.base_url, "/summary", summary_payload)
+        _validate_summary_shape(summary_obj)
+        summary_latencies.append(summary_ms)
+
+        qa_payload = {
+            "input_path": args.summary_input_path,
+            "question": "what observations exist?",
+            "citation_limit": 5,
+        }
+        qa_obj, qa_ms = _post_json(args.base_url, "/qa", qa_payload)
+        _validate_qa_shape(qa_obj)
+        qa_latencies.append(qa_ms)
+
+    pipeline_root = Path(args.pipeline_out)
+    for i in range(args.pipeline_iterations):
+        elapsed = _run_pipeline_once(args.pipeline_input_path, pipeline_root / f"run_{i + 1}")
+        pipeline_times.append(elapsed)
+
+    summary_stats = _stats(summary_latencies)
+    qa_stats = _stats(qa_latencies)
+    pipeline_stats = _stats(pipeline_times)
+
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    out = {
+        "timestamp_utc": now,
+        "base_url": args.base_url,
+        "summary_input_path": args.summary_input_path,
+        "pipeline_input_path": args.pipeline_input_path,
+        "metrics": {
+            "summary": {
+                "count": int(summary_stats["count"]),
+                "min_ms": summary_stats["min"],
+                "max_ms": summary_stats["max"],
+                "p50_ms": summary_stats["p50"],
+                "p95_ms": summary_stats["p95"],
+            },
+            "qa": {
+                "count": int(qa_stats["count"]),
+                "min_ms": qa_stats["min"],
+                "max_ms": qa_stats["max"],
+                "p50_ms": qa_stats["p50"],
+                "p95_ms": qa_stats["p95"],
+            },
+            "pipeline": {
+                "count": int(pipeline_stats["count"]),
+                "min_s": pipeline_stats["min"],
+                "max_s": pipeline_stats["max"],
+                "p50_s": pipeline_stats["p50"],
+                "p95_s": pipeline_stats["p95"],
+            },
+        },
+    }
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(out, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    _write_markdown(Path(args.out_md), out)
+    print(f"wrote benchmark results: {out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_orin_benchmark_thresholds.py
+++ b/tests/test_orin_benchmark_thresholds.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestOrinBenchmarkThresholds(unittest.TestCase):
+    def _write_json(self, path: Path, obj: dict) -> None:
+        path.write_text(json.dumps(obj, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    def test_threshold_check_passes_when_within_limits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            results = root / "results.json"
+            thresholds = root / "thresholds.json"
+            self._write_json(
+                results,
+                {
+                    "metrics": {
+                        "summary": {"p95_ms": 9000.0, "p50_ms": 5000.0},
+                        "qa": {"p95_ms": 10000.0, "p50_ms": 6000.0},
+                        "pipeline": {"p95_s": 30.0},
+                    }
+                },
+            )
+            self._write_json(
+                thresholds,
+                {
+                    "metrics": {
+                        "summary.p95_ms": {"max": 12000.0},
+                        "summary.p50_ms": {"max": 6000.0},
+                        "qa.p95_ms": {"max": 12000.0},
+                        "qa.p50_ms": {"max": 7000.0},
+                        "pipeline.p95_s": {"max": 45.0},
+                    }
+                },
+            )
+            proc = subprocess.run(
+                ["python3", "scripts/cd/check_benchmark_thresholds.py", "--results", str(results), "--thresholds", str(thresholds)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            self.assertIn("benchmark threshold check passed", proc.stdout)
+
+    def test_threshold_check_fails_with_explicit_metric_message(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            results = root / "results.json"
+            thresholds = root / "thresholds.json"
+            self._write_json(
+                results,
+                {
+                    "metrics": {
+                        "summary": {"p95_ms": 15000.0},
+                        "qa": {"p95_ms": 10000.0},
+                        "pipeline": {"p95_s": 30.0},
+                    }
+                },
+            )
+            self._write_json(thresholds, {"metrics": {"summary.p95_ms": {"max": 12000.0}}})
+            proc = subprocess.run(
+                ["python3", "scripts/cd/check_benchmark_thresholds.py", "--results", str(results), "--thresholds", str(thresholds)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 1)
+            self.assertIn("metric=summary.p95_ms", proc.stdout)
+            self.assertIn("threshold<=", proc.stdout)
+            self.assertIn("observed=", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #162

## What
- add ORIN benchmark workflow at `.github/workflows/orin_backend_benchmark.yml` running on `[self-hosted, linux, orin]`
- add `scripts/cd/orin_benchmark_backend.py` to benchmark `/summary`, `/qa`, and `healthdelta pipeline run` with deterministic JSON+Markdown outputs
- add `scripts/cd/check_benchmark_thresholds.py` to enforce regression thresholds with explicit metric/threshold/observed messages
- add baseline thresholds in `deploy/orin/benchmark_thresholds.json`
- update `docs/runbook_orin_deploy.md` with benchmark operation and local reproduction commands
- update `docs/plan.md` status for governance carryover and active Issue #162 roadmap item
- add unit tests for threshold checking in `tests/test_orin_benchmark_thresholds.py`
- add required audit artifacts for issue #162 under `.ai/`

## Why
This closes the current post-MMF performance-proof gap by adding reproducible benchmark evidence and CI gating for ORIN backend runtime envelopes.

## Verification
- `TZ=UTC python3 -m unittest tests/test_orin_benchmark_thresholds.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`

Closes #162
