### PR TITLE
Issue: #166 - Minimal secure upload + archive API for iOS

### DIFF
--- a/.ai/prompts/issue_166.md
+++ b/.ai/prompts/issue_166.md
@@ -1,0 +1,20 @@
+# Issue #166 Prompt (Immutable)
+
+Implement a minimal authenticated upload + dataset control API in the existing backend server.
+
+Scope:
+- Add endpoints:
+  - GET /datasets/current
+  - POST /datasets/archive
+  - GET /datasets/archives
+  - POST /upload-sessions
+  - PUT /upload-sessions/{id}/chunks/{index}
+  - POST /upload-sessions/{id}/finalize
+  - GET /upload-sessions/{id}
+- Require bearer auth for new endpoints via `HEALTHDELTA_UPLOAD_TOKEN`.
+  - If unset, return 503 with actionable error.
+- Store data under `HEALTHDELTA_DATA_DIR` (default `/data`) with on-disk session metadata/chunks.
+- Finalize must assemble chunks into export.zip, verify size and optional sha256, publish dataset, and manage current pointer.
+- Add tests for bookkeeping/path handling and an integration-style endpoint flow.
+- Update runbooks with token configuration and curl chunk-upload examples.
+- Keep /healthz and /version behavior unchanged.

--- a/.ai/sessions/2026-02-02/session_18.md
+++ b/.ai/sessions/2026-02-02/session_18.md
@@ -1,0 +1,19 @@
+# Session 18 - 2026-02-02
+
+Issue: #166
+
+Goal
+- Add minimal secure upload + archive API for iOS export.zip control.
+
+Notes
+- Added `healthdelta/upload_plane.py` for filesystem-backed upload sessions, finalize, current pointer, archive/list operations.
+- Extended backend server routes with authenticated upload endpoints and structured JSON logging.
+- Added token gate behavior: upload endpoints return 503 with remediation when token unset.
+- Wired ORIN compose/deploy path to pass upload token and explicit data root.
+- Added tests for upload-plane bookkeeping and integration-style API flow.
+- Updated ORIN/CD runbooks with token setup and curl chunk-upload examples.
+
+Local verification
+- TZ=UTC python3 -m unittest tests/test_upload_plane.py -v
+- TZ=UTC python3 -m unittest tests/test_backend_upload_api.py -v
+- TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -101,3 +101,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-02-02,159,UNASSIGNED,10,codex,UNASSIGNED,"Correct delta epoch expectations in SyncStatusStoreTests from macOS CI evidence"
 2026-02-02,162,UNASSIGNED,70,codex,UNASSIGNED,"ORIN benchmark workflow + threshold checker + runbook integration"
 2026-02-02,164,UNASSIGNED,60,codex,UNASSIGNED,"Persistent ORIN data-plane mount + deploy verification sentinel persistence"
+2026-02-02,166,UNASSIGNED,90,codex,UNASSIGNED,"Backend upload/dataset API with bearer auth, resumable sessions, finalize/archive/list endpoints"

--- a/.github/workflows/deploy_backend_orin.yml
+++ b/.github/workflows/deploy_backend_orin.yml
@@ -74,6 +74,7 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts/orin-deploy
           TAG="${{ steps.v.outputs.tag }}" VERSION="${{ steps.v.outputs.ver }}" GIT_SHA="${{ steps.v.outputs.sha }}" \
+            HEALTHDELTA_UPLOAD_TOKEN="${{ secrets.HEALTHDELTA_UPLOAD_TOKEN }}" \
             DEPLOY_DIR="/opt/healthdelta" SERVICE_NAME="backend" BASE_URL="http://127.0.0.1:8080" \
             bash scripts/cd/orin_deploy_backend.sh | tee artifacts/orin-deploy/deploy_verify.log
 

--- a/deploy/orin/compose.yaml
+++ b/deploy/orin/compose.yaml
@@ -7,5 +7,7 @@ services:
       - "8080:8080"
     environment:
       PORT: "8080"
+      HEALTHDELTA_DATA_DIR: "/app/data"
+      HEALTHDELTA_UPLOAD_TOKEN: "${HEALTHDELTA_UPLOAD_TOKEN:-}"
     volumes:
       - /opt/healthdelta/data:/app/data

--- a/docs/runbook_cd.md
+++ b/docs/runbook_cd.md
@@ -80,6 +80,10 @@ For ORIN deploy proof artifacts, include:
 - sentinel write/read success
 - sentinel persistence across restart
 
+For iOS/TestFlight dataset control, backend upload endpoints are gated by:
+- `HEALTHDELTA_UPLOAD_TOKEN` (bearer token auth)
+- `HEALTHDELTA_DATA_DIR` (defaults to `/data`; ORIN deploy sets `/app/data` via bind mount)
+
 Planning/sequence is tracked by:
 - `docs/plan.md` Orin phase issues: #120-#128.
 

--- a/docs/runbook_orin_deploy.md
+++ b/docs/runbook_orin_deploy.md
@@ -42,7 +42,10 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
 3) Tools required for verification
    - `curl`
    - `python3`
-4) Deploy directory permissions
+4) Upload API token (required for iOS/TestFlight upload control endpoints)
+   - Set `HEALTHDELTA_UPLOAD_TOKEN` to a long random value (stored as secret in deployment workflow context).
+   - The backend returns `503 upload_unavailable` on upload endpoints when token is unset.
+5) Deploy directory permissions
    - Required one-time bootstrap (no sudo during workflow execution):
      - `sudo mkdir -p /opt/healthdelta`
      - `sudo mkdir -p /opt/healthdelta/data`
@@ -71,6 +74,39 @@ This runbook covers the ORIN-side prerequisites and operational commands for bac
   - trend analysis (`metric`, `window_days`, `direction`, `confidence`, `delta`) with explicit insufficiency reporting
   - mandatory disclaimer string stating flags are not medical advice
   - PHI token guard check result (`phi_tokens_checked`, `phi_token_hits`)
+
+## Upload + dataset control API (Issue #166)
+All endpoints require `Authorization: Bearer <HEALTHDELTA_UPLOAD_TOKEN>`.
+
+- `POST /upload-sessions` create resumable session
+- `PUT /upload-sessions/{id}/chunks/{index}` upload chunk bytes
+- `POST /upload-sessions/{id}/finalize` assemble + verify + publish dataset
+- `GET /upload-sessions/{id}` inspect session status
+- `GET /datasets/current` show active dataset
+- `POST /datasets/archive` archive active dataset
+- `GET /datasets/archives` list archived datasets
+
+Example (2-chunk upload via curl):
+
+```bash
+TOKEN="<your_token>"
+BASE="http://127.0.0.1:8080"
+
+echo -n 'hello-' > /tmp/chunk0.bin
+echo -n 'world' > /tmp/chunk1.bin
+TOTAL=$(( $(wc -c < /tmp/chunk0.bin) + $(wc -c < /tmp/chunk1.bin) ))
+SHA="$(cat /tmp/chunk0.bin /tmp/chunk1.bin | sha256sum | awk '{print $1}')"
+
+SID="$(curl -fsS -X POST "$BASE/upload-sessions" \
+  -H "authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  --data "{\"total_size\":$TOTAL,\"sha256\":\"$SHA\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')"
+
+curl -fsS -X PUT "$BASE/upload-sessions/$SID/chunks/0" -H "authorization: Bearer $TOKEN" --data-binary @/tmp/chunk0.bin
+curl -fsS -X PUT "$BASE/upload-sessions/$SID/chunks/1" -H "authorization: Bearer $TOKEN" --data-binary @/tmp/chunk1.bin
+curl -fsS -X POST "$BASE/upload-sessions/$SID/finalize" -H "authorization: Bearer $TOKEN"
+curl -fsS "$BASE/datasets/current" -H "authorization: Bearer $TOKEN"
+```
 
 ## Verification (“150%” backend checks)
 The deploy workflow verifies:

--- a/healthdelta/backend_server.py
+++ b/healthdelta/backend_server.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import time
+from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ from healthdelta.ndjson_export import export_ndjson
 from healthdelta.qa import answer_question
 from healthdelta.risk_flags import build_risk_flags
 from healthdelta.trends import build_trend_analysis
+from healthdelta.upload_plane import UploadPlane, UploadPlaneError
 from healthdelta.version import get_build_info
 
 
@@ -211,8 +213,73 @@ def _run_grounded_qa(*, input_path: str, work_dir: str, question: str, citation_
 
 
 class _Handler(BaseHTTPRequestHandler):
+    _session_status_re = re.compile(r"^/upload-sessions/([A-Za-z0-9]+)$")
+    _chunk_put_re = re.compile(r"^/upload-sessions/([A-Za-z0-9]+)/chunks/(\d+)$")
+    _session_finalize_re = re.compile(r"^/upload-sessions/([A-Za-z0-9]+)/finalize$")
+
     def log_message(self, format: str, *args: object) -> None:  # noqa: A002
         return
+
+    def _log_event(self, event: str, **fields: Any) -> None:
+        payload: dict[str, Any] = {
+            "ts": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "event": event,
+            "method": self.command,
+            "path": self.path,
+            "remote": self.client_address[0] if self.client_address else "",
+        }
+        payload.update(fields)
+        print(json.dumps(payload, sort_keys=True), flush=True)
+
+    def _upload_plane(self) -> UploadPlane:
+        data_root = Path(os.getenv("HEALTHDELTA_DATA_DIR", "/data"))
+        return UploadPlane(data_root)
+
+    def _authorize_upload(self) -> bool:
+        token = os.getenv("HEALTHDELTA_UPLOAD_TOKEN", "").strip()
+        if not token:
+            self._send_json(
+                503,
+                {
+                    "error": "upload_unavailable",
+                    "detail": "upload endpoints are disabled; set HEALTHDELTA_UPLOAD_TOKEN to enable them",
+                },
+            )
+            self._log_event("upload_auth_rejected", status=503, reason="token_unset")
+            return False
+        authz = self.headers.get("Authorization", "")
+        if authz != f"Bearer {token}":
+            self._send_json(401, {"error": "unauthorized", "detail": "expected Authorization: Bearer <token>"})
+            self._log_event("upload_auth_rejected", status=401, reason="invalid_bearer")
+            return False
+        return True
+
+    def _read_json_body(self) -> dict[str, Any]:
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            raise UploadPlaneError(400, "invalid_content_length", "Content-Length must be a valid integer")
+        if content_length < 0:
+            raise UploadPlaneError(400, "invalid_content_length", "Content-Length must be >= 0")
+        raw = self.rfile.read(content_length)
+        if not raw:
+            return {}
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except Exception as exc:
+            raise UploadPlaneError(400, "invalid_json", f"request body is not valid JSON: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise UploadPlaneError(400, "invalid_payload", "request JSON must be an object")
+        return payload
+
+    def _read_raw_body(self) -> bytes:
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            raise UploadPlaneError(400, "invalid_content_length", "Content-Length must be a valid integer")
+        if content_length <= 0:
+            raise UploadPlaneError(400, "invalid_content_length", "Content-Length must be > 0 for chunk upload")
+        return self.rfile.read(content_length)
 
     def _send_json(self, status: int, obj: object) -> None:
         body = (json.dumps(obj, sort_keys=True) + "\n").encode("utf-8")
@@ -223,64 +290,189 @@ class _Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_GET(self) -> None:  # noqa: N802
+        self._log_event("request_received")
         if self.path == "/healthz":
             self._send_json(200, healthz_payload())
+            self._log_event("request_succeeded", status=200)
             return
         if self.path == "/version":
             self._send_json(200, version_payload())
+            self._log_event("request_succeeded", status=200)
+            return
+        if self.path == "/datasets/current":
+            if not self._authorize_upload():
+                return
+            try:
+                obj = self._upload_plane().get_current_dataset()
+                self._send_json(200, obj)
+                self._log_event("request_succeeded", status=200, dataset=obj.get("dataset"))
+            except UploadPlaneError as exc:
+                self._send_json(exc.status, {"error": exc.code, "detail": exc.detail})
+                self._log_event("request_failed", status=exc.status, error=exc.code)
+            return
+        if self.path == "/datasets/archives":
+            if not self._authorize_upload():
+                return
+            try:
+                archives = self._upload_plane().list_archives()
+                self._send_json(200, {"archives": archives})
+                self._log_event("request_succeeded", status=200, archive_count=len(archives))
+            except UploadPlaneError as exc:
+                self._send_json(exc.status, {"error": exc.code, "detail": exc.detail})
+                self._log_event("request_failed", status=exc.status, error=exc.code)
+            return
+        session_match = self._session_status_re.match(self.path)
+        if session_match:
+            if not self._authorize_upload():
+                return
+            session_id = session_match.group(1)
+            try:
+                obj = self._upload_plane().get_session(session_id)
+                self._send_json(200, obj)
+                self._log_event("request_succeeded", status=200, session_id=session_id)
+            except UploadPlaneError as exc:
+                self._send_json(exc.status, {"error": exc.code, "detail": exc.detail})
+                self._log_event("request_failed", status=exc.status, error=exc.code, session_id=session_id)
             return
         self._send_json(404, {"error": "not_found"})
+        self._log_event("request_failed", status=404, error="not_found")
 
     def do_POST(self) -> None:  # noqa: N802
-        if self.path not in {"/summary", "/qa"}:
-            self._send_json(404, {"error": "not_found"})
+        self._log_event("request_received")
+        if self.path in {"/summary", "/qa"}:
+            try:
+                payload = self._read_json_body()
+            except UploadPlaneError as exc:
+                self._send_json(exc.status, {"error": exc.code, "detail": exc.detail})
+                self._log_event("request_failed", status=exc.status, error=exc.code)
+                return
+            input_path = payload.get("input_path")
+            if not isinstance(input_path, str) or not input_path.strip():
+                self._send_json(400, {"error": "input_path_required"})
+                self._log_event("request_failed", status=400, error="input_path_required")
+                return
+            work_dir = payload.get("work_dir")
+            if not isinstance(work_dir, str) or not work_dir.strip():
+                work_dir = "data/backend_slice"
+            citation_limit = payload.get("citation_limit")
+            if not isinstance(citation_limit, int) or citation_limit <= 0:
+                citation_limit = 12
+            citation_limit = min(citation_limit, 50)
+            try:
+                if self.path == "/summary":
+                    obj = _run_vertical_slice(input_path=input_path, work_dir=work_dir, citation_limit=citation_limit)
+                else:
+                    question = payload.get("question")
+                    if not isinstance(question, str) or not question.strip():
+                        self._send_json(400, {"error": "question_required"})
+                        self._log_event("request_failed", status=400, error="question_required")
+                        return
+                    obj = _run_grounded_qa(
+                        input_path=input_path,
+                        work_dir=work_dir,
+                        question=question,
+                        citation_limit=min(citation_limit, 20),
+                    )
+            except FileNotFoundError as e:
+                self._send_json(400, {"error": "input_not_found", "detail": str(e)})
+                self._log_event("request_failed", status=400, error="input_not_found")
+                return
+            except Exception as e:
+                self._send_json(500, {"error": "summary_failed", "detail": str(e)})
+                self._log_event("request_failed", status=500, error="summary_failed")
+                return
+            self._send_json(200, obj)
+            self._log_event("request_succeeded", status=200)
             return
-        try:
-            content_length = int(self.headers.get("Content-Length", "0"))
-        except ValueError:
-            self._send_json(400, {"error": "invalid_content_length"})
+
+        if self.path == "/upload-sessions":
+            if not self._authorize_upload():
+                return
+            try:
+                payload = self._read_json_body()
+                total_size = payload.get("total_size")
+                if not isinstance(total_size, int):
+                    raise UploadPlaneError(400, "invalid_total_size", "total_size must be an integer")
+                sha256 = payload.get("sha256")
+                if sha256 is not None and not isinstance(sha256, str):
+                    raise UploadPlaneError(400, "invalid_sha256", "sha256 must be a string when provided")
+                obj = self._upload_plane().create_session(total_size=total_size, sha256=sha256)
+                self._send_json(201, obj)
+                self._log_event("upload_session_created", status=201, session_id=obj.get("id"), total_size=total_size)
+            except UploadPlaneError as exc:
+                self._send_json(exc.status, {"error": exc.code, "detail": exc.detail})
+                self._log_event("request_failed", status=exc.status, error=exc.code)
             return
-        raw = self.rfile.read(max(content_length, 0))
-        try:
-            payload = json.loads(raw.decode("utf-8")) if raw else {}
-        except Exception:
-            self._send_json(400, {"error": "invalid_json"})
+
+        if self.path == "/datasets/archive":
+            if not self._authorize_upload():
+                return
+            try:
+                obj = self._upload_plane().archive_current()
+                self._send_json(200, obj)
+                self._log_event("dataset_archived", status=200, archive=obj.get("archive"))
+            except UploadPlaneError as exc:
+                self._send_json(exc.status, {"error": exc.code, "detail": exc.detail})
+                self._log_event("request_failed", status=exc.status, error=exc.code)
             return
-        if not isinstance(payload, dict):
-            self._send_json(400, {"error": "invalid_payload"})
-            return
-        input_path = payload.get("input_path")
-        if not isinstance(input_path, str) or not input_path.strip():
-            self._send_json(400, {"error": "input_path_required"})
-            return
-        work_dir = payload.get("work_dir")
-        if not isinstance(work_dir, str) or not work_dir.strip():
-            work_dir = "data/backend_slice"
-        citation_limit = payload.get("citation_limit")
-        if not isinstance(citation_limit, int) or citation_limit <= 0:
-            citation_limit = 12
-        citation_limit = min(citation_limit, 50)
-        try:
-            if self.path == "/summary":
-                obj = _run_vertical_slice(input_path=input_path, work_dir=work_dir, citation_limit=citation_limit)
-            else:
-                question = payload.get("question")
-                if not isinstance(question, str) or not question.strip():
-                    self._send_json(400, {"error": "question_required"})
-                    return
-                obj = _run_grounded_qa(
-                    input_path=input_path,
-                    work_dir=work_dir,
-                    question=question,
-                    citation_limit=min(citation_limit, 20),
+
+        finalize_match = self._session_finalize_re.match(self.path)
+        if finalize_match:
+            if not self._authorize_upload():
+                return
+            session_id = finalize_match.group(1)
+            try:
+                obj = self._upload_plane().finalize_session(session_id)
+                self._send_json(200, obj)
+                self._log_event(
+                    "upload_session_finalized",
+                    status=200,
+                    session_id=session_id,
+                    dataset=obj.get("finalized_dataset"),
                 )
-        except FileNotFoundError as e:
-            self._send_json(400, {"error": "input_not_found", "detail": str(e)})
+            except UploadPlaneError as exc:
+                self._send_json(exc.status, {"error": exc.code, "detail": exc.detail})
+                self._log_event("request_failed", status=exc.status, error=exc.code, session_id=session_id)
             return
-        except Exception as e:
-            self._send_json(500, {"error": "summary_failed", "detail": str(e)})
+
+        self._send_json(404, {"error": "not_found"})
+        self._log_event("request_failed", status=404, error="not_found")
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self._log_event("request_received")
+        match = self._chunk_put_re.match(self.path)
+        if not match:
+            self._send_json(404, {"error": "not_found"})
+            self._log_event("request_failed", status=404, error="not_found")
             return
-        self._send_json(200, obj)
+        if not self._authorize_upload():
+            return
+
+        session_id = match.group(1)
+        chunk_index = int(match.group(2))
+        try:
+            content = self._read_raw_body()
+            obj = self._upload_plane().put_chunk(session_id, chunk_index, content)
+            self._send_json(
+                200,
+                {
+                    "id": obj.get("id"),
+                    "status": obj.get("status"),
+                    "received_chunks": obj.get("received_chunks"),
+                    "received_bytes": obj.get("received_bytes"),
+                    "updated_at": obj.get("updated_at"),
+                },
+            )
+            self._log_event(
+                "upload_chunk_stored",
+                status=200,
+                session_id=session_id,
+                chunk_index=chunk_index,
+                bytes=len(content),
+            )
+        except UploadPlaneError as exc:
+            self._send_json(exc.status, {"error": exc.code, "detail": exc.detail})
+            self._log_event("request_failed", status=exc.status, error=exc.code, session_id=session_id, chunk_index=chunk_index)
 
 
 def make_server(*, host: str, port: int) -> ThreadingHTTPServer:

--- a/healthdelta/upload_plane.py
+++ b/healthdelta/upload_plane.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _timestamp_slug() -> str:
+    return datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+@dataclass
+class UploadPlaneError(Exception):
+    status: int
+    code: str
+    detail: str
+
+
+class UploadPlane:
+    """File-system-backed upload sessions + dataset pointer management."""
+
+    def __init__(self, data_root: Path):
+        self.data_root = Path(data_root)
+        self.uploads_root = self.data_root / "uploads"
+        self.datasets_root = self.data_root / "datasets"
+        self.archives_root = self.data_root / "archives"
+        self.current_symlink = self.datasets_root / "current"
+        self.current_fallback = self.datasets_root / "current.txt"
+        self.ensure_layout()
+
+    def ensure_layout(self) -> None:
+        for p in (self.data_root, self.uploads_root, self.datasets_root, self.archives_root):
+            p.mkdir(parents=True, exist_ok=True)
+
+    def create_session(self, *, total_size: int, sha256: str | None = None) -> dict[str, Any]:
+        if total_size <= 0:
+            raise UploadPlaneError(400, "invalid_total_size", "total_size must be a positive integer")
+        if sha256 is not None:
+            normalized = sha256.strip().lower()
+            if len(normalized) != 64 or any(ch not in "0123456789abcdef" for ch in normalized):
+                raise UploadPlaneError(400, "invalid_sha256", "sha256 must be a 64-character hex string")
+            sha256 = normalized
+
+        session_id = uuid.uuid4().hex[:12]
+        session_dir = self._session_dir(session_id)
+        chunks_dir = session_dir / "chunks"
+        chunks_dir.mkdir(parents=True, exist_ok=False)
+        obj: dict[str, Any] = {
+            "id": session_id,
+            "status": "created",
+            "created_at": _now_utc_iso(),
+            "updated_at": _now_utc_iso(),
+            "total_size": int(total_size),
+            "sha256": sha256,
+            "received_chunks": [],
+            "received_bytes": 0,
+            "finalized_dataset": None,
+        }
+        self._write_session_json(session_id, obj)
+        return obj
+
+    def get_session(self, session_id: str) -> dict[str, Any]:
+        obj = self._read_session_json(session_id)
+        chunk_indexes = self._received_chunk_indexes(session_id)
+        obj["received_chunks"] = chunk_indexes
+        obj["received_bytes"] = self._total_chunk_bytes(session_id, chunk_indexes)
+        return obj
+
+    def put_chunk(self, session_id: str, index: int, content: bytes) -> dict[str, Any]:
+        if index < 0:
+            raise UploadPlaneError(400, "invalid_chunk_index", "chunk index must be >= 0")
+        if len(content) == 0:
+            raise UploadPlaneError(400, "invalid_chunk", "chunk body cannot be empty")
+
+        obj = self._read_session_json(session_id)
+        if obj.get("status") == "finalized":
+            raise UploadPlaneError(409, "session_finalized", "cannot upload chunks after finalize")
+
+        chunk_path = self._chunk_path(session_id, index)
+        chunk_path.parent.mkdir(parents=True, exist_ok=True)
+        chunk_path.write_bytes(content)
+
+        indexes = self._received_chunk_indexes(session_id)
+        obj["received_chunks"] = indexes
+        obj["received_bytes"] = self._total_chunk_bytes(session_id, indexes)
+        obj["status"] = "uploading"
+        obj["updated_at"] = _now_utc_iso()
+        self._write_session_json(session_id, obj)
+        return obj
+
+    def finalize_session(self, session_id: str) -> dict[str, Any]:
+        obj = self._read_session_json(session_id)
+        if obj.get("status") == "finalized":
+            return obj
+
+        indexes = self._received_chunk_indexes(session_id)
+        if not indexes:
+            raise UploadPlaneError(400, "missing_chunks", "no chunks uploaded")
+        expected = list(range(0, indexes[-1] + 1))
+        if indexes != expected:
+            raise UploadPlaneError(
+                400,
+                "missing_chunks",
+                f"chunk indexes must be contiguous from 0..{indexes[-1]}; got {indexes}",
+            )
+
+        assembled = self._session_dir(session_id) / "export.zip"
+        with assembled.open("wb") as out:
+            for idx in indexes:
+                out.write(self._chunk_path(session_id, idx).read_bytes())
+
+        assembled_size = assembled.stat().st_size
+        expected_size = int(obj.get("total_size") or 0)
+        if assembled_size != expected_size:
+            raise UploadPlaneError(
+                400,
+                "size_mismatch",
+                f"assembled size {assembled_size} does not match expected total_size {expected_size}",
+            )
+
+        expected_sha = obj.get("sha256")
+        if expected_sha:
+            actual_sha = hashlib.sha256(assembled.read_bytes()).hexdigest()
+            if actual_sha != expected_sha:
+                raise UploadPlaneError(
+                    400,
+                    "sha256_mismatch",
+                    f"assembled sha256 {actual_sha} does not match expected {expected_sha}",
+                )
+
+        short_id = session_id[:6]
+        dataset_name = f"dataset_{_timestamp_slug()}_{short_id}"
+        dataset_dir = self.datasets_root / dataset_name
+        dataset_dir.mkdir(parents=True, exist_ok=False)
+        destination = dataset_dir / "export.zip"
+        shutil.move(str(assembled), str(destination))
+
+        self._set_current_dataset(dataset_name)
+        obj["status"] = "finalized"
+        obj["finalized_dataset"] = dataset_name
+        obj["updated_at"] = _now_utc_iso()
+        obj["received_chunks"] = indexes
+        obj["received_bytes"] = expected_size
+        self._write_session_json(session_id, obj)
+        return obj
+
+    def get_current_dataset(self) -> dict[str, Any]:
+        name = self._current_dataset_name()
+        if not name:
+            raise UploadPlaneError(404, "no_current_dataset", "no current dataset is set")
+        dataset_dir = self.datasets_root / name
+        export_zip = dataset_dir / "export.zip"
+        if not export_zip.exists():
+            raise UploadPlaneError(
+                500,
+                "current_dataset_missing",
+                f"current dataset '{name}' is missing export.zip at {export_zip}",
+            )
+        return {
+            "dataset": name,
+            "path": str(dataset_dir),
+            "export_zip": str(export_zip),
+            "size_bytes": export_zip.stat().st_size,
+            "updated_at": _now_utc_iso(),
+        }
+
+    def archive_current(self) -> dict[str, Any]:
+        name = self._current_dataset_name()
+        if not name:
+            raise UploadPlaneError(404, "no_current_dataset", "no current dataset is set")
+        src = self.datasets_root / name
+        if not src.exists():
+            raise UploadPlaneError(500, "current_dataset_missing", f"current dataset dir does not exist: {src}")
+        archive_name = f"archive_{_timestamp_slug()}_{name}"
+        dst = self.archives_root / archive_name
+        shutil.move(str(src), str(dst))
+        self._clear_current_dataset()
+        return {
+            "archived_dataset": name,
+            "archive": archive_name,
+            "path": str(dst),
+            "updated_at": _now_utc_iso(),
+        }
+
+    def list_archives(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for p in sorted(self.archives_root.iterdir()):
+            if not p.is_dir():
+                continue
+            export_zip = p / "export.zip"
+            out.append(
+                {
+                    "archive": p.name,
+                    "path": str(p),
+                    "has_export_zip": export_zip.exists(),
+                    "size_bytes": export_zip.stat().st_size if export_zip.exists() else 0,
+                }
+            )
+        return out
+
+    def _session_dir(self, session_id: str) -> Path:
+        if not session_id or "/" in session_id or ".." in session_id:
+            raise UploadPlaneError(400, "invalid_session_id", "session id is invalid")
+        return self.uploads_root / f"session_{session_id}"
+
+    def _session_json_path(self, session_id: str) -> Path:
+        return self._session_dir(session_id) / "session.json"
+
+    def _chunk_path(self, session_id: str, index: int) -> Path:
+        return self._session_dir(session_id) / "chunks" / f"{index:06d}"
+
+    def _read_session_json(self, session_id: str) -> dict[str, Any]:
+        path = self._session_json_path(session_id)
+        if not path.exists():
+            raise UploadPlaneError(404, "session_not_found", f"upload session '{session_id}' was not found")
+        try:
+            obj = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise UploadPlaneError(500, "session_corrupt", f"session metadata is unreadable: {exc}") from exc
+        if not isinstance(obj, dict):
+            raise UploadPlaneError(500, "session_corrupt", "session metadata JSON is not an object")
+        return obj
+
+    def _write_session_json(self, session_id: str, obj: dict[str, Any]) -> None:
+        path = self._session_json_path(session_id)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(obj, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+
+    def _received_chunk_indexes(self, session_id: str) -> list[int]:
+        chunks_dir = self._session_dir(session_id) / "chunks"
+        if not chunks_dir.exists():
+            return []
+        indexes: list[int] = []
+        for p in chunks_dir.iterdir():
+            if not p.is_file():
+                continue
+            try:
+                indexes.append(int(p.name))
+            except ValueError:
+                continue
+        return sorted(indexes)
+
+    def _total_chunk_bytes(self, session_id: str, indexes: list[int]) -> int:
+        total = 0
+        for idx in indexes:
+            total += self._chunk_path(session_id, idx).stat().st_size
+        return total
+
+    def _set_current_dataset(self, dataset_name: str) -> None:
+        self._clear_current_dataset()
+        target = self.datasets_root / dataset_name
+        if not target.exists():
+            raise UploadPlaneError(500, "dataset_missing", f"dataset path does not exist: {target}")
+        try:
+            self.current_symlink.symlink_to(dataset_name)
+        except OSError:
+            self.current_fallback.write_text(dataset_name + "\n", encoding="utf-8")
+
+    def _clear_current_dataset(self) -> None:
+        if self.current_symlink.exists() or self.current_symlink.is_symlink():
+            self.current_symlink.unlink()
+        if self.current_fallback.exists():
+            self.current_fallback.unlink()
+
+    def _current_dataset_name(self) -> str | None:
+        if self.current_symlink.is_symlink():
+            target = self.current_symlink.readlink()
+            return target.name
+        if self.current_fallback.exists():
+            name = self.current_fallback.read_text(encoding="utf-8").strip()
+            return name or None
+        return None

--- a/scripts/cd/orin_deploy_backend.sh
+++ b/scripts/cd/orin_deploy_backend.sh
@@ -11,6 +11,7 @@ BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
 TAG="${TAG:?tag to deploy (e.g., v0.0.2)}"
 VERSION="${VERSION:?expected version (e.g., 0.0.2)}"
 GIT_SHA="${GIT_SHA:?expected git sha}"
+UPLOAD_TOKEN="${HEALTHDELTA_UPLOAD_TOKEN:-}"
 
 if [ ! -d "$DEPLOY_DIR" ]; then
   echo "ERROR: deploy dir '$DEPLOY_DIR' is missing." >&2
@@ -43,7 +44,12 @@ fi
 cp "$REPO_ROOT/deploy/orin/compose.yaml" "$DEPLOY_DIR/compose.yaml"
 cat >"$DEPLOY_DIR/.env" <<EOF
 HEALTHDELTA_BACKEND_IMAGE_TAG=$TAG
+HEALTHDELTA_UPLOAD_TOKEN=$UPLOAD_TOKEN
 EOF
+
+if [ -z "$UPLOAD_TOKEN" ]; then
+  echo "WARN: HEALTHDELTA_UPLOAD_TOKEN is unset; upload endpoints will return 503 until configured."
+fi
 
 cd "$DEPLOY_DIR"
 

--- a/tests/test_backend_upload_api.py
+++ b/tests/test_backend_upload_api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from healthdelta.backend_server import make_server
+
+
+class TestBackendUploadAPI(unittest.TestCase):
+    def setUp(self) -> None:
+        self._old_data = os.environ.get("HEALTHDELTA_DATA_DIR")
+        self._old_token = os.environ.get("HEALTHDELTA_UPLOAD_TOKEN")
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["HEALTHDELTA_DATA_DIR"] = self._tmp.name
+        os.environ["HEALTHDELTA_UPLOAD_TOKEN"] = "test-token"
+        self.server = make_server(host="127.0.0.1", port=0)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        time.sleep(0.05)
+        host, port = self.server.server_address
+        self.base_url = f"http://{host}:{port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self._tmp.cleanup()
+        if self._old_data is None:
+            os.environ.pop("HEALTHDELTA_DATA_DIR", None)
+        else:
+            os.environ["HEALTHDELTA_DATA_DIR"] = self._old_data
+        if self._old_token is None:
+            os.environ.pop("HEALTHDELTA_UPLOAD_TOKEN", None)
+        else:
+            os.environ["HEALTHDELTA_UPLOAD_TOKEN"] = self._old_token
+
+    def _request(self, method: str, path: str, *, body: bytes | None = None, auth: bool = True) -> tuple[int, dict]:
+        headers: dict[str, str] = {}
+        if auth:
+            headers["Authorization"] = "Bearer test-token"
+        if body is not None and method != "PUT":
+            headers["Content-Type"] = "application/json"
+        req = Request(self.base_url + path, data=body, headers=headers, method=method)
+        try:
+            with urlopen(req) as resp:
+                return resp.status, json.loads(resp.read().decode("utf-8"))
+        except HTTPError as err:
+            payload = json.loads(err.read().decode("utf-8"))
+            return err.code, payload
+
+    def test_upload_finalize_archive_flow(self) -> None:
+        payload = b"hello-" + b"world"
+        sha = hashlib.sha256(payload).hexdigest()
+        status, created = self._request(
+            "POST",
+            "/upload-sessions",
+            body=json.dumps({"total_size": len(payload), "sha256": sha}).encode("utf-8"),
+        )
+        self.assertEqual(status, 201)
+        sid = created["id"]
+
+        st0, _ = self._request("PUT", f"/upload-sessions/{sid}/chunks/0", body=b"hello-")
+        self.assertEqual(st0, 200)
+        st1, _ = self._request("PUT", f"/upload-sessions/{sid}/chunks/1", body=b"world")
+        self.assertEqual(st1, 200)
+
+        st_status, session_state = self._request("GET", f"/upload-sessions/{sid}")
+        self.assertEqual(st_status, 200)
+        self.assertEqual(session_state["received_chunks"], [0, 1])
+
+        st_fin, finalized = self._request("POST", f"/upload-sessions/{sid}/finalize", body=b"{}")
+        self.assertEqual(st_fin, 200)
+        self.assertEqual(finalized["status"], "finalized")
+
+        st_curr, current = self._request("GET", "/datasets/current")
+        self.assertEqual(st_curr, 200)
+        self.assertTrue(current["dataset"].startswith("dataset_"))
+
+        st_arch, archived = self._request("POST", "/datasets/archive", body=b"{}")
+        self.assertEqual(st_arch, 200)
+        self.assertTrue(archived["archive"].startswith("archive_"))
+
+        st_list, archives = self._request("GET", "/datasets/archives")
+        self.assertEqual(st_list, 200)
+        self.assertEqual(len(archives["archives"]), 1)
+
+    def test_upload_endpoints_reject_when_token_missing(self) -> None:
+        os.environ.pop("HEALTHDELTA_UPLOAD_TOKEN", None)
+        status, payload = self._request("GET", "/datasets/archives", auth=False)
+        self.assertEqual(status, 503)
+        self.assertEqual(payload["error"], "upload_unavailable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_upload_plane.py
+++ b/tests/test_upload_plane.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from healthdelta.upload_plane import UploadPlane
+
+
+class TestUploadPlane(unittest.TestCase):
+    def test_session_bookkeeping_and_finalize(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            plane = UploadPlane(Path(tmp))
+            payload = b"abc123xyz"
+            sha = hashlib.sha256(payload).hexdigest()
+            session = plane.create_session(total_size=len(payload), sha256=sha)
+            sid = session["id"]
+
+            plane.put_chunk(sid, 0, b"abc")
+            plane.put_chunk(sid, 1, b"123xyz")
+            status = plane.get_session(sid)
+            self.assertEqual(status["received_chunks"], [0, 1])
+            self.assertEqual(status["received_bytes"], len(payload))
+
+            finalized = plane.finalize_session(sid)
+            dataset = finalized["finalized_dataset"]
+            self.assertIsNotNone(dataset)
+
+            current = plane.get_current_dataset()
+            self.assertEqual(current["dataset"], dataset)
+            export_zip = Path(current["export_zip"])
+            self.assertTrue(export_zip.exists())
+            self.assertEqual(export_zip.read_bytes(), payload)
+
+    def test_archive_current_clears_pointer_and_lists_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            plane = UploadPlane(Path(tmp))
+            session = plane.create_session(total_size=4, sha256=hashlib.sha256(b"data").hexdigest())
+            sid = session["id"]
+            plane.put_chunk(sid, 0, b"data")
+            plane.finalize_session(sid)
+
+            archived = plane.archive_current()
+            self.assertIn("archive_", archived["archive"])
+            archives = plane.list_archives()
+            self.assertEqual(len(archives), 1)
+            self.assertTrue(archives[0]["has_export_zip"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #166

## What
- add authenticated dataset/upload API endpoints to `healthdelta.backend_server`:
  - `GET /datasets/current`
  - `POST /datasets/archive`
  - `GET /datasets/archives`
  - `POST /upload-sessions`
  - `PUT /upload-sessions/{id}/chunks/{index}`
  - `POST /upload-sessions/{id}/finalize`
  - `GET /upload-sessions/{id}`
- keep `/healthz` and `/version` unchanged
- require bearer auth on new endpoints via `HEALTHDELTA_UPLOAD_TOKEN`
  - if token unset, endpoints return `503 upload_unavailable` with remediation text
- add filesystem-backed upload/session/dataset manager in `healthdelta/upload_plane.py`
  - data root from `HEALTHDELTA_DATA_DIR` (default `/data`)
  - persisted session metadata/chunks
  - finalize assembly with total-size + optional sha256 verification
  - current dataset pointer + archive listing
- add structured JSON log lines for endpoint calls and major state transitions
- wire ORIN deploy path to pass upload token and explicit data dir env:
  - `deploy/orin/compose.yaml`
  - `.github/workflows/deploy_backend_orin.yml`
  - `scripts/cd/orin_deploy_backend.sh`
- update runbooks with token setup and curl chunk-upload examples:
  - `docs/runbook_orin_deploy.md`
  - `docs/runbook_cd.md`
- add tests:
  - `tests/test_upload_plane.py`
  - `tests/test_backend_upload_api.py`

## Why
This enables minimal secure iOS/TestFlight control over export.zip transfer and dataset lifecycle without introducing a heavy framework or changing existing health/version behavior.

## Verification
- `TZ=UTC python3 -m unittest tests/test_upload_plane.py -v`
- `TZ=UTC python3 -m unittest tests/test_backend_upload_api.py -v`
- `TZ=UTC python3 -m unittest tests/test_audit_artifacts.py -v`

Closes #166
