### PR TITLE
Isolate dashboard patient-scope unit tests

### DIFF
--- a/.ai/prompts/issue_254.md
+++ b/.ai/prompts/issue_254.md
@@ -1,0 +1,6 @@
+# Issue 254 Prompt
+
+Fix DashboardViewModel unit tests that leak live ORIN patient-scope requests.
+Inject `FakePatientScopeFetcher` in successful upload and dashboard-refresh test
+fixtures that exercise patient-scope refreshes. Do not change production backend
+configuration, ORIN labels, or patient-scope service behavior.

--- a/.ai/sessions/2026-06-01/session_1.md
+++ b/.ai/sessions/2026-06-01/session_1.md
@@ -1,0 +1,16 @@
+# Session 1 - DashboardViewModel patient-scope test isolation
+
+Date: 2026-06-01
+Issue: #254
+
+## Summary
+- Investigated macOS Xcode CI run `26786904590`.
+- Confirmed the first attempt lost runner communication during `xcodebuild`.
+- Reran the macOS job after the runner returned online and downloaded the uploaded `ios-xcresult` artifact.
+- Found repeated test-launch restart boundaries and an unintended request to `http://orin.local:8080/patients/current`.
+- Added fake patient-scope fetchers to the successful upload and dashboard-refresh fixtures that exercise patient-scope refreshes.
+
+## Verification
+- Red evidence: `xcodebuild` exit `65` in macOS job `78966444764`.
+- `git diff --check`: passed.
+- Authoritative macOS CI rerun: pending.

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -198,3 +198,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-03-13,245,UNASSIGNED,20,codex,UNASSIGNED,"Fix /patients/current permission failure on Apple bootstrap dataset"
 2026-03-13,246,UNASSIGNED,20,codex,UNASSIGNED,"Fix iPhone app freeze during initial load and refresh"
 2026-03-14,247,UNASSIGNED,20,codex,UNASSIGNED,"Replace row-count-only ORIN insight cards with meaningful summaries"
+2026-06-01,254,UNASSIGNED,20,codex,UNASSIGNED,"Fix iOS DashboardViewModel unit tests leaking live ORIN patient-scope requests"

--- a/ios/HealthDelta/Tests/DashboardViewModelTests.swift
+++ b/ios/HealthDelta/Tests/DashboardViewModelTests.swift
@@ -281,7 +281,8 @@ final class DashboardViewModelTests: XCTestCase {
             insightsStore: FakeInsightsStore(cards: []),
             manualExporter: FakeManualExporter(),
             runUploader: uploader,
-            insightsFetcher: FakeInsightsFetcher()
+            insightsFetcher: FakeInsightsFetcher(),
+            patientScopeFetcher: FakePatientScopeFetcher()
         )
 
         viewModel.refresh()
@@ -382,7 +383,8 @@ final class DashboardViewModelTests: XCTestCase {
             insightsStore: FakeInsightsStore(cards: []),
             manualExporter: FakeManualExporter(),
             runUploader: uploader,
-            insightsFetcher: FakeInsightsFetcher()
+            insightsFetcher: FakeInsightsFetcher(),
+            patientScopeFetcher: FakePatientScopeFetcher()
         )
 
         viewModel.refresh()
@@ -446,7 +448,8 @@ final class DashboardViewModelTests: XCTestCase {
             insightsStore: FakeInsightsStore(cards: []),
             manualExporter: FakeManualExporter(),
             runUploader: uploader,
-            insightsFetcher: FakeInsightsFetcher()
+            insightsFetcher: FakeInsightsFetcher(),
+            patientScopeFetcher: FakePatientScopeFetcher()
         )
 
         viewModel.refresh()
@@ -574,7 +577,8 @@ final class DashboardViewModelTests: XCTestCase {
             insightsStore: FakeInsightsStore(cards: localCards),
             manualExporter: FakeManualExporter(),
             runUploader: FakeRunUploader(),
-            insightsFetcher: FakeInsightsFetcher(result: .cards(remoteCards))
+            insightsFetcher: FakeInsightsFetcher(result: .cards(remoteCards)),
+            patientScopeFetcher: FakePatientScopeFetcher()
         )
 
         await viewModel.refreshDashboard(baseURLString: "http://orin.local:8080", bearerToken: "token")


### PR DESCRIPTION
Issue: #254

## Summary
- inject fake patient-scope fetchers into successful upload and dashboard-refresh tests
- prevent DashboardViewModel unit tests from leaking live `/patients/current` requests
- preserve production backend behavior and legacy display labels

## Verification
- red evidence: https://github.com/dave0875/HealthDelta/actions/runs/26786904590/job/78966444764
- `git diff --check`
- authoritative macOS CI on this PR
