### PR TITLE
Issue: #249 - Fix FHIR export validation edge cases

### DIFF
--- a/.ai/prompts/issue_249.md
+++ b/.ai/prompts/issue_249.md
@@ -1,0 +1,14 @@
+Issue #249: Fix FHIR export validation for patient references, null optional fields, and id-less resources
+
+Source of truth: GitHub Issue #249
+
+Scope:
+- Normalize patient.reference as a fallback subject_reference for canonical clinical rows.
+- Omit optional JSON-null fields from canonical FHIR NDJSON rows.
+- Generate deterministic non-empty source_id values for id-less FHIR resources without exposing payload content.
+- Add focused regression coverage proving normalized output passes NDJSON validation.
+
+Non-goals:
+- No streaming-memory refactor.
+- No malformed CDA repair.
+- No backend deployment changes.

--- a/.ai/sessions/2026-06-02/session_1.md
+++ b/.ai/sessions/2026-06-02/session_1.md
@@ -1,0 +1,16 @@
+# Session 1
+
+Issue: #249
+
+## Prompt
+Fix FHIR export validation edge cases for patient references, null optional fields, and id-less resources, then prepare the issue branch for CI.
+
+## Work
+- Kept the issue-scoped FHIR export changes isolated on the #249 branch.
+- Verified the targeted real-world FHIR validation edge test locally.
+- Added this audit entry and a time.csv row for the PR session.
+
+## Verification
+- `.venv/bin/python -m unittest tests.test_ndjson_export.TestNdjsonExport.test_export_ndjson_normalizes_real_world_fhir_validation_edges -v`
+- `.venv/bin/python -m py_compile healthdelta/duckdb_tools.py tests/test_duckdb.py healthdelta/ndjson_export.py tests/test_ndjson_export.py`
+- `git diff --check`

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -203,3 +203,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-06-01,250,UNASSIGNED,20,codex,UNASSIGNED,"Add bulk DuckDB load path for fresh canonical NDJSON baselines"
 2026-06-01,251,UNASSIGNED,20,codex,UNASSIGNED,"Fix ORIN benchmark workflow dependency bootstrap"
 2026-06-01,254,UNASSIGNED,20,codex,UNASSIGNED,"Fix iOS DashboardViewModel unit tests leaking live ORIN patient-scope requests"
+2026-06-02,249,UNASSIGNED,20,codex,UNASSIGNED,"Prepare FHIR export validation edge-case fix for issue-scoped PR and CI"

--- a/healthdelta/ndjson_export.py
+++ b/healthdelta/ndjson_export.py
@@ -320,6 +320,24 @@ def _extract_fhir_reference_id(ref: str, resource_type: str) -> str | None:
     return None
 
 
+def _fhir_subject_reference(resource: dict) -> str | None:
+    for key in ("subject", "patient"):
+        ref = resource.get(key)
+        if not isinstance(ref, dict):
+            continue
+        value = ref.get("reference")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _fhir_source_id(resource_type: str, resource_id: str | None, rel: str) -> str:
+    if resource_id:
+        return f"{resource_type}/{resource_id}"
+    digest = _sha256_bytes(_safe_relpath(rel).encode("utf-8"))[:16]
+    return f"{resource_type}/source-{digest}"
+
+
 def _first_fhir_coding_value(codable: object, field: str) -> str | None:
     if not isinstance(codable, dict):
         return None
@@ -659,8 +677,11 @@ def _export_fhir_streams(
             "event_time": event_time,
             "run_id": ctx.run_id,
             "resource_type": rt,
-            "source_id": f"{rt}/{rid}" if rid else None,
+            "source_id": _fhir_source_id(rt, rid, rel),
         }
+        subject_reference = _fhir_subject_reference(res)
+        if subject_reference is not None:
+            base["subject_reference"] = subject_reference
 
         def register_source_record_key(row: dict) -> None:
             source_id = row.get("source_id")
@@ -1875,14 +1896,15 @@ def export_ndjson(*, input_dir: str, out_dir: str, mode: str = "local") -> None:
         seen: set[str] = set()
         out: list[dict] = []
         for r in rows:
-            k = r.get("event_key")
+            cleaned = {key: value for key, value in r.items() if value is not None or key == "event_time"}
+            k = cleaned.get("event_key")
             if not isinstance(k, str):
-                k = _sha256_bytes(json.dumps(r, sort_keys=True, separators=(",", ":")).encode("utf-8"))
-                r["event_key"] = k
+                k = _sha256_bytes(json.dumps(cleaned, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+                cleaned["event_key"] = k
             if k in seen:
                 continue
             seen.add(k)
-            out.append(r)
+            out.append(cleaned)
         return out
 
     def sort_rows(rows: list[dict]) -> list[dict]:

--- a/tests/test_ndjson_export.py
+++ b/tests/test_ndjson_export.py
@@ -6,6 +6,9 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from healthdelta.ndjson_export import export_ndjson
+from healthdelta.ndjson_validate import validate_ndjson_dir
+
 
 HEALTHKIT_EXPORT_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <HealthData>
@@ -418,6 +421,60 @@ def _read_ndjson(path: Path) -> list[dict]:
 
 
 class TestNdjsonExport(unittest.TestCase):
+    def test_export_ndjson_normalizes_real_world_fhir_validation_edges(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            run_dir = root / "staging" / "run-fhir-validation"
+            clinical_dir = run_dir / "source" / "clinical-records"
+            clinical_dir.mkdir(parents=True, exist_ok=True)
+
+            resources = {
+                "allergy.json": {
+                    "resourceType": "AllergyIntolerance",
+                    "id": "allergy-patient-reference",
+                    "patient": {"reference": "Patient/p1"},
+                    "recordedDate": "2020-01-01T00:00:00Z",
+                    "clinicalStatus": {"coding": [{"code": "active"}]},
+                    "code": {"coding": [{"system": "urn:test", "code": "allergy"}]},
+                },
+                "diagnostic-report.json": {
+                    "resourceType": "DiagnosticReport",
+                    "id": "report-text-code-only",
+                    "subject": {"reference": "Patient/p1"},
+                    "issued": "2020-01-02T00:00:00Z",
+                    "status": "final",
+                    "code": {"text": "Text-only report code"},
+                },
+                "immunization-without-id.json": {
+                    "resourceType": "Immunization",
+                    "patient": {"reference": "Patient/p1"},
+                    "occurrenceDateTime": "2020-01-03T00:00:00Z",
+                    "status": "completed",
+                    "vaccineCode": {"coding": [{"system": "urn:test", "code": "vaccine"}]},
+                },
+            }
+            for name, resource in resources.items():
+                _write_json(clinical_dir / name, resource)
+            _write_json(
+                run_dir / "layout.json",
+                {
+                    "run_id": "run-fhir-validation",
+                    "clinical_json": [f"source/clinical-records/{name}" for name in sorted(resources)],
+                },
+            )
+
+            out = root / "ndjson"
+            export_ndjson(input_dir=str(run_dir), out_dir=str(out), mode="local")
+
+            allergy = _read_ndjson(out / "conditions.ndjson")[0]
+            self.assertEqual(allergy["subject_reference"], "Patient/p1")
+            report = _read_ndjson(out / "diagnostic_reports.ndjson")[0]
+            self.assertNotIn("code", report)
+            self.assertNotIn("code_system", report)
+            immunization = _read_ndjson(out / "observations.ndjson")[0]
+            self.assertTrue(immunization["source_id"].startswith("Immunization/source-"))
+            self.assertEqual(validate_ndjson_dir(input_dir=str(out)), [])
+
     def test_export_ndjson_uses_clinical_records_fixture_pack(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## Summary
- Resolve FHIR subject references from subject or patient fields.
- Add deterministic fallback source IDs for id-less FHIR resources.
- Preserve objective validation coverage for real-world FHIR edge cases.

Issue: #249

## Verification
- .venv/bin/python -m unittest tests.test_ndjson_export.TestNdjsonExport.test_export_ndjson_normalizes_real_world_fhir_validation_edges -v
- .venv/bin/python -m py_compile healthdelta/duckdb_tools.py tests/test_duckdb.py healthdelta/ndjson_export.py tests/test_ndjson_export.py
- git diff --check
