### PR TITLE
Issue: #250 - Add bulk DuckDB canonical baseline loader

### DIFF
--- a/.ai/prompts/issue_250.md
+++ b/.ai/prompts/issue_250.md
@@ -1,0 +1,13 @@
+Issue #250: Add bulk DuckDB load path for fresh canonical NDJSON baselines
+
+Source of truth: GitHub Issue #250
+
+Scope:
+- Add DuckDB-side bulk projection for fresh canonical observations NDJSON imports.
+- Preserve deterministic dedupe and existing append-safe behavior.
+- Add focused regression coverage.
+
+Non-goals:
+- No schema changes.
+- No report-content changes.
+- No private data changes.

--- a/.ai/sessions/2026-06-02/session_2.md
+++ b/.ai/sessions/2026-06-02/session_2.md
@@ -1,0 +1,17 @@
+# Session 2
+
+Issue: #250
+
+## Prompt
+Add a bulk DuckDB canonical baseline loader and fix the timestamp contract so SQL and Python ingest paths store plain TIMESTAMP values consistently.
+
+## Work
+- Added canonical SQL timestamp normalization for bulk DuckDB loads.
+- Changed Python timestamp parsing to insert naive UTC values into DuckDB TIMESTAMP columns.
+- Forced the DuckDB regression test through a non-UTC timezone to catch local-time shifts.
+
+## Verification
+- `.venv/bin/python -m py_compile healthdelta/duckdb_tools.py tests/test_duckdb.py healthdelta/ndjson_export.py tests/test_ndjson_export.py`
+- `.venv/bin/python -m unittest tests.test_duckdb -v` skipped locally because this `.venv` lacks duckdb
+- `.venv/bin/python -m unittest tests.test_ndjson_export.TestNdjsonExport.test_export_ndjson_normalizes_real_world_fhir_validation_edges -v`
+- `git diff --check`

--- a/.ai/time/time.csv
+++ b/.ai/time/time.csv
@@ -204,3 +204,4 @@ date,issue_id,client,minutes,agent,activity,notes
 2026-06-01,251,UNASSIGNED,20,codex,UNASSIGNED,"Fix ORIN benchmark workflow dependency bootstrap"
 2026-06-01,254,UNASSIGNED,20,codex,UNASSIGNED,"Fix iOS DashboardViewModel unit tests leaking live ORIN patient-scope requests"
 2026-06-02,249,UNASSIGNED,20,codex,UNASSIGNED,"Prepare FHIR export validation edge-case fix for issue-scoped PR and CI"
+2026-06-02,250,UNASSIGNED,20,codex,UNASSIGNED,"Prepare DuckDB bulk loader timestamp contract fix for issue-scoped PR and CI"

--- a/healthdelta/duckdb_tools.py
+++ b/healthdelta/duckdb_tools.py
@@ -44,7 +44,7 @@ def _parse_event_time(s: object) -> dt.datetime | None:
         d = dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
         if d.tzinfo is None:
             d = d.replace(tzinfo=dt.timezone.utc)
-        return d.astimezone(dt.timezone.utc).replace(microsecond=0)
+        return d.astimezone(dt.timezone.utc).replace(tzinfo=None, microsecond=0)
     except ValueError:
         return None
 
@@ -163,6 +163,13 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
             con.execute("PRAGMA threads=1;")
             con.execute("PRAGMA enable_progress_bar=false;")
             con.execute("BEGIN;")
+            con.execute(
+                """
+                CREATE OR REPLACE MACRO parse_canonical_ts(value) AS (
+                  TRY_CAST(regexp_replace(trim(value), 'Z$', '') AS TIMESTAMP)
+                );
+                """
+            )
 
         with progress.phase("duckdb: ensure schema"):
             con.execute(
@@ -364,8 +371,8 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                       NULL,
                       ?,
                       COALESCE(
-                        TRY_CAST(json_extract_string(payload, '$.event_time') AS TIMESTAMP),
-                        TRY_CAST(json_extract_string(payload, '$.start_time') AS TIMESTAMP)
+                        parse_canonical_ts(json_extract_string(payload, '$.event_time')),
+                        parse_canonical_ts(json_extract_string(payload, '$.start_time'))
                       ),
                       ?,
                       COALESCE(NULLIF(json_extract_string(payload, '$.event_key'), ''), resolved_record_key),
@@ -421,6 +428,98 @@ def build_duckdb(*, input_dir: str, db_path: str, replace: bool = False) -> None
                 )
                 inserted = con.execute("SELECT COUNT(*) FROM observations;").fetchone()
                 task.advance(int(inserted[0]) if inserted and inserted[0] is not None else 0)
+            elif append_only:
+                with progress.phase("duckdb: bulk load canonical observations"):
+                    con.execute(
+                        """
+                        WITH src AS (
+                          SELECT
+                            json AS payload,
+                            COALESCE(
+                              NULLIF(json_extract_string(json, '$.record_key'), ''),
+                              NULLIF(json_extract_string(json, '$.event_key'), '')
+                            ) AS resolved_record_key,
+                            ROW_NUMBER() OVER (
+                              PARTITION BY COALESCE(
+                                NULLIF(json_extract_string(json, '$.record_key'), ''),
+                                NULLIF(json_extract_string(json, '$.event_key'), '')
+                              )
+                              ORDER BY
+                                COALESCE(json_extract_string(json, '$.event_time'), ''),
+                                COALESCE(json_extract_string(json, '$.source'), ''),
+                                COALESCE(json_extract_string(json, '$.source_file'), '')
+                            ) AS resolved_record_key_rank
+                          FROM read_ndjson_objects(?)
+                        )
+                        INSERT INTO observations (
+                          """
+                        + observation_columns_sql
+                        + """
+                        )
+                        SELECT
+                          TRY_CAST(json_extract_string(payload, '$.schema_version') AS INTEGER),
+                          resolved_record_key,
+                          json_extract_string(payload, '$.canonical_person_id'),
+                          json_extract_string(payload, '$.source'),
+                          json_extract_string(payload, '$.source_system'),
+                          json_extract_string(payload, '$.source_file'),
+                          parse_canonical_ts(json_extract_string(payload, '$.event_time')),
+                          json_extract_string(payload, '$.run_id'),
+                          COALESCE(NULLIF(json_extract_string(payload, '$.event_key'), ''), resolved_record_key),
+                          json_extract_string(payload, '$.source_id'),
+                          json_extract_string(payload, '$.record_id'),
+                          json_extract_string(payload, '$.record_type'),
+                          json_extract_string(payload, '$.observation_id'),
+                          json_extract_string(payload, '$.subject_reference'),
+                          json_extract_string(payload, '$.encounter_id'),
+                          parse_canonical_ts(json_extract_string(payload, '$.effective_start')),
+                          parse_canonical_ts(json_extract_string(payload, '$.effective_end')),
+                          COALESCE(
+                            json_extract_string(payload, '$.hk_type'),
+                            json_extract_string(payload, '$.sample_type')
+                          ),
+                          json_extract_string(payload, '$.sample_kind'),
+                          json_extract_string(payload, '$.resource_type'),
+                          json_extract_string(payload, '$.code_system'),
+                          json_extract_string(payload, '$.code'),
+                          COALESCE(
+                            json_extract_string(payload, '$.display'),
+                            json_extract_string(payload, '$.value_text'),
+                            json_extract_string(payload, '$.activity_type')
+                          ),
+                          COALESCE(
+                            json_extract_string(payload, '$.value'),
+                            json_extract_string(payload, '$.value_num')
+                          ),
+                          COALESCE(
+                            TRY_CAST(json_extract_string(payload, '$.value_num') AS DOUBLE),
+                            TRY_CAST(json_extract_string(payload, '$.value') AS DOUBLE)
+                          ),
+                          json_extract_string(payload, '$.value_text'),
+                          TRY_CAST(json_extract_string(payload, '$.category_value') AS INTEGER),
+                          json_extract_string(payload, '$.activity_type'),
+                          TRY_CAST(json_extract_string(payload, '$.duration_seconds') AS DOUBLE),
+                          TRY_CAST(json_extract_string(payload, '$.total_energy_burned_num') AS DOUBLE),
+                          json_extract_string(payload, '$.total_energy_burned_unit'),
+                          TRY_CAST(json_extract_string(payload, '$.total_distance_num') AS DOUBLE),
+                          json_extract_string(payload, '$.total_distance_unit'),
+                          json_extract_string(payload, '$.unit'),
+                          json_extract_string(payload, '$.section_code'),
+                          json_extract_string(payload, '$.section_display'),
+                          json_extract_string(payload, '$.section_title'),
+                          CAST(json_extract(payload, '$.components') AS VARCHAR),
+                          CAST(json_extract(payload, '$.code_coding') AS VARCHAR),
+                          CAST(json_extract(payload, '$.type_coding') AS VARCHAR),
+                          json_extract_string(payload, '$.status')
+                        FROM src
+                        WHERE resolved_record_key IS NOT NULL
+                          AND resolved_record_key <> ''
+                          AND resolved_record_key_rank = 1;
+                        """,
+                        [str(observations_path)],
+                    )
+                    inserted = con.execute("SELECT COUNT(*) FROM observations;").fetchone()
+                    task.advance(int(inserted[0]) if inserted and inserted[0] is not None else 0)
             else:
                 batch_rows: list[list[object]] = []
                 seen_record_keys: set[str] = set()

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -1,4 +1,5 @@
 import csv
+import os
 import subprocess
 import sys
 import tempfile
@@ -81,6 +82,7 @@ class TestDuckdbLoader(unittest.TestCase):
             _write_text(ndjson / "diagnostic_reports.ndjson", diagnostic_reports)
 
             db_path = root / "out.duckdb"
+            duckdb_env = {**os.environ, "TZ": "America/New_York"}
 
             build = subprocess.run(
                 [
@@ -97,8 +99,10 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(build.returncode, 0, msg=f"stdout={build.stdout}\nstderr={build.stderr}")
+            self.assertIn("phase start name=duckdb: bulk load canonical observations", build.stderr)
             self.assertTrue(db_path.exists())
 
             # Verify tables exist and row counts.
@@ -116,6 +120,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q1.returncode, 0, msg=f"stdout={q1.stdout}\nstderr={q1.stderr}")
             rows = list(csv.DictReader(q1.stdout.splitlines()))
@@ -136,6 +141,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q1b.returncode, 0, msg=f"stdout={q1b.stdout}\nstderr={q1b.stderr}")
             rows = list(csv.DictReader(q1b.stdout.splitlines()))
@@ -166,6 +172,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q2.returncode, 0, msg=f"stdout={q2.stdout}\nstderr={q2.stderr}")
             rows = list(csv.DictReader(q2.stdout.splitlines()))
@@ -185,6 +192,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q3.returncode, 0, msg=f"stdout={q3.stdout}\nstderr={q3.stderr}")
             rows = list(csv.DictReader(q3.stdout.splitlines()))
@@ -204,6 +212,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q3b.returncode, 0, msg=f"stdout={q3b.stdout}\nstderr={q3b.stderr}")
             rows = list(csv.DictReader(q3b.stdout.splitlines()))
@@ -233,6 +242,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q4.returncode, 0, msg=f"stdout={q4.stdout}\nstderr={q4.stderr}")
             rows = list(csv.DictReader(q4.stdout.splitlines()))
@@ -252,6 +262,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q5.returncode, 0, msg=f"stdout={q5.stdout}\nstderr={q5.stderr}")
             rows = list(csv.DictReader(q5.stdout.splitlines()))
@@ -271,6 +282,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q6.returncode, 0, msg=f"stdout={q6.stdout}\nstderr={q6.stderr}")
             rows = list(csv.DictReader(q6.stdout.splitlines()))
@@ -304,6 +316,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(build2.returncode, 0, msg=f"stdout={build2.stdout}\nstderr={build2.stderr}")
 
@@ -322,6 +335,7 @@ class TestDuckdbLoader(unittest.TestCase):
                 ],
                 capture_output=True,
                 text=True,
+                env=duckdb_env,
             )
             self.assertEqual(q1b.returncode, 0, msg=f"stdout={q1b.stdout}\nstderr={q1b.stderr}")
             rows = list(csv.DictReader(q1b.stdout.splitlines()))


### PR DESCRIPTION
## Summary
- Add a bulk DuckDB load path for canonical observations.
- Keep canonical timestamps as naive UTC wall-clock values for plain TIMESTAMP tables across Python and SQL ingest paths.
- Force the DuckDB regression test through America/New_York so timezone shifts are observable in CI.

Issue: #250

## Verification
- .venv/bin/python -m py_compile healthdelta/duckdb_tools.py tests/test_duckdb.py healthdelta/ndjson_export.py tests/test_ndjson_export.py
- .venv/bin/python -m unittest tests.test_duckdb -v (local environment skipped because duckdb is not installed)
- .venv/bin/python -m unittest tests.test_ndjson_export.TestNdjsonExport.test_export_ndjson_normalizes_real_world_fhir_validation_edges -v
- git diff --check

## Note
This PR is stacked on #256 so the diff remains limited to #250. After #256 merges, retarget this PR to main before merge.
